### PR TITLE
Non-working root NS support, abandoned

### DIFF
--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -41,6 +41,7 @@ _PROXIABLE_RECORD_TYPES = {'A', 'AAAA', 'ALIAS', 'CNAME'}
 class CloudflareProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
+    SUPPORTS_ROOT_NS = True
     SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS',
                     'PTR', 'SRV', 'SPF', 'TXT', 'URLFWD'))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ fqdn==1.5.1
 idna==3.3
 iniconfig==1.1.1
 natsort==8.1.0
-octodns==0.9.14
 packaging==21.3
 pluggy==1.0.0
 pprintpp==0.4.0
@@ -26,3 +25,5 @@ six==1.16.0
 toml==0.10.2
 tomli==2.0.0
 urllib3==1.26.8
+
+-e git+https://git@github.com/github/octodns.git@root-ns-support#egg=octodns


### PR DESCRIPTION
So interestingly you can edit the root `NS` records in cloudflare to your hearts content, but it completely ignores what you set into them:

### With no root NS record in the system

```console
$ dig +short NS xormedia.com @ben.ns.cloudflare.com
ben.ns.cloudflare.com.
tegan.ns.cloudflare.com.
```

### When I add my actual NS records

```yaml
  - type: NS
    values:
      - ns1-03.azure-dns.com.
      - ns2-03.azure-dns.net.
      - ns3-03.azure-dns.org.
      - ns4-03.azure-dns.info.
```

```console
$ dig +short NS xormedia.com @ben.ns.cloudflare.com
ben.ns.cloudflare.com.
tegan.ns.cloudflare.com.
```

### Trying to include the Cloudflare nameservers in the root record throws an error

```console
(env) coho:octodns-cloudflare ross$ PYTHONPATH=. octodns-sync --config-file=config/dev.yaml --doit --force
2022-02-21T14:09:00  [4714372608] INFO  Manager __init__: config_file=config/dev.yaml
2022-02-21T14:09:00  [4714372608] INFO  Manager __init__:   max_workers=1
2022-02-21T14:09:00  [4714372608] INFO  Manager __init__:   include_meta=False
2022-02-21T14:09:00  [4714372608] INFO  Manager sync: eligible_zones=[], eligible_targets=[], dry_run=False, force=True, plan_output_fh=<stdout>
2022-02-21T14:09:00  [4714372608] INFO  Manager sync:   zone=xormedia.com.
2022-02-21T14:09:00  [4714372608] INFO  Manager sync:   sources=['config'] -> targets=['cloudflare']
2022-02-21T14:09:00  [4714372608] INFO  YamlProvider[config] populate:   found 3 records, exists=False
2022-02-21T14:09:00  [4714372608] INFO  CloudflareProvider[cloudflare] plan: desired=xormedia.com.
2022-02-21T14:09:00  [4714372608] INFO  CloudflareProvider[cloudflare] populate:   found 3 records, exists=True
2022-02-21T14:09:00  [4714372608] INFO  CloudflareProvider[cloudflare] plan:   Creates=0, Updates=1, Deletes=0, Existing Records=3
2022-02-21T14:09:00  [4714372608] INFO  Manager
********************************************************************************
* xormedia.com.
********************************************************************************
* cloudflare (CloudflareProvider)
*   Update
*     <NsRecord NS 3600, xormedia.com., ['ns1-03.azure-dns.com.', 'ns2-03.azure-dns.net.', 'ns3-03.azure-dns.org.', 'ns4-03.azure-dns.info.']> ->
*     <NsRecord NS 3600, xormedia.com., ['ben.ns.cloudflare.com.', 'tegan.ns.cloudflare.com.']> (config)
*   Summary: Creates=0, Updates=1, Deletes=0, Existing Records=3
********************************************************************************


2022-02-21T14:09:00  [4714372608] INFO  CloudflareProvider[cloudflare] apply: making 1 changes to xormedia.com.
Traceback (most recent call last):
  File "/Users/ross/octodns/octodns-cloudflare/env/bin/octodns-sync", line 33, in <module>
    sys.exit(load_entry_point('octodns', 'console_scripts', 'octodns-sync')())
  File "/Users/ross/octodns/octodns-cloudflare/env/src/octodns/octodns/cmds/sync.py", line 38, in main
    manager.sync(eligible_zones=args.zone, eligible_sources=args.source,
  File "/Users/ross/octodns/octodns-cloudflare/env/src/octodns/octodns/manager.py", line 469, in sync
    total_changes += target.apply(plan)
  File "/Users/ross/octodns/octodns-cloudflare/env/src/octodns/octodns/provider/base.py", line 226, in apply
    self._apply(plan)
  File "/Users/ross/octodns/octodns-cloudflare/octodns_cloudflare/__init__.py", line 800, in _apply
    getattr(self, f'_apply_{class_name}')(change)
  File "/Users/ross/octodns/octodns-cloudflare/octodns_cloudflare/__init__.py", line 736, in _apply_Update
    self._try_request('PUT', path, data=data)
  File "/Users/ross/octodns/octodns-cloudflare/octodns_cloudflare/__init__.py", line 85, in _try_request
    return self._request(*args, **kwargs)
  File "/Users/ross/octodns/octodns-cloudflare/octodns_cloudflare/__init__.py", line 104, in _request
    raise CloudflareError(resp.json())
octodns_cloudflare.CloudflareError: Content for NS record is invalid. NS records at the apex must not overwrite assigned nameservers.
```

Same thing happens when I try and add the Cloudflare namesrvers along side my actual nameservers. 

### TL;DR

You can sort of edit the root NS record of Cloudflare, but it's restricted in weird ways and ignored anyway so no `SUPPORTS_ROOT_NS = True` for you.

/cc https://github.com/octodns/octodns-cloudflare/issues/11
/cc https://github.com/octodns/octodns/pull/876