### PR TITLE
Add option to disable page-rule creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ providers:
     #
     # See: https://support.cloudflare.com/hc/en-us/articles/115000830351
     #cdn: false
+    # Manage Page Rules (URLFWD) records
+    # pagerules: true
     # Optional. Default: 4. Number of times to retry if a 429 response
     # is received.
     #retry_count: 4

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -78,6 +78,9 @@ class CloudflareProvider(BaseProvider):
         self._zones = None
         self._zone_records = {}
         if self.pagerules:
+            # copy the class static/ever present list of supported types into an instance property so that 
+            # when we modify it we won't change the shared version
+            self.SUPPORTS = set(self.SUPPORTS)
             self.SUPPORTS.add('URLFWD')
 
     def _try_request(self, *args, **kwargs):

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -42,7 +42,7 @@ class CloudflareProvider(BaseProvider):
     SUPPORTS_GEO = False
     SUPPORTS_DYNAMIC = False
     SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS',
-                    'PTR', 'SRV', 'SPF', 'TXT', 'URLFWD'))
+                    'PTR', 'SRV', 'SPF', 'TXT'))
 
     MIN_TTL = 120
     TIMEOUT = 15
@@ -77,9 +77,8 @@ class CloudflareProvider(BaseProvider):
 
         self._zones = None
         self._zone_records = {}
-        if not self.pagerules:
-            self.SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS',
-                    'PTR', 'SRV', 'SPF', 'TXT'))
+        if self.pagerules:
+            self.SUPPORTS.add('URLFWD')
 
     def _try_request(self, *args, **kwargs):
         tries = self.retry_count
@@ -613,7 +612,7 @@ class CloudflareProvider(BaseProvider):
     def _apply_Create(self, change):
         new = change.new
         zone_id = self.zones[new.zone.name]
-        if new._type == 'URLFWD' and self.pagerules:
+        if new._type == 'URLFWD':
             path = f'/zones/{zone_id}/pagerules'
         else:
             path = f'/zones/{zone_id}/dns_records'
@@ -717,7 +716,7 @@ class CloudflareProvider(BaseProvider):
         # otherwise required, just makes things deterministic
 
         # Creates
-        if _type == 'URLFWD' and self.pagerules:
+        if _type == 'URLFWD':
             path = f'/zones/{zone_id}/pagerules'
         else:
             path = f'/zones/{zone_id}/dns_records'
@@ -730,7 +729,7 @@ class CloudflareProvider(BaseProvider):
             record_id = info['record_id']
             data = info['data']
             old_data = info['old_data']
-            if _type == 'URLFWD' and self.pagerules:
+            if _type == 'URLFWD':
                 path = f'/zones/{zone_id}/pagerules/{record_id}'
             else:
                 path = f'/zones/{zone_id}/dns_records/{record_id}'
@@ -742,7 +741,7 @@ class CloudflareProvider(BaseProvider):
         for _, info in sorted(deletes.items()):
             record_id = info['record_id']
             old_data = info['data']
-            if _type == 'URLFWD' and self.pagerules:
+            if _type == 'URLFWD':
                 path = f'/zones/{zone_id}/pagerules/{record_id}'
             else:
                 path = f'/zones/{zone_id}/dns_records/{record_id}'

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -48,8 +48,8 @@ class CloudflareProvider(BaseProvider):
     TIMEOUT = 15
 
     def __init__(self, id, email=None, token=None, cdn=False, pagerules=True,
-                retry_count=4, retry_period=300, zones_per_page=50,
-                records_per_page=100, *args, **kwargs):
+                 retry_count=4, retry_period=300, zones_per_page=50,
+                 records_per_page=100, *args, **kwargs):
         self.log = getLogger(f'CloudflareProvider[{id}]')
         self.log.debug('__init__: id=%s, email=%s, token=***, cdn=%s', id,
                        email, cdn)
@@ -78,8 +78,9 @@ class CloudflareProvider(BaseProvider):
         self._zones = None
         self._zone_records = {}
         if self.pagerules:
-            # copy the class static/ever present list of supported types into an instance property so that 
-            # when we modify it we won't change the shared version
+            # copy the class static/ever present list of supported types into
+            # an instance property so that when we modify it we won't change
+            # the shared version
             self.SUPPORTS = set(self.SUPPORTS)
             self.SUPPORTS.add('URLFWD')
 
@@ -294,7 +295,8 @@ class CloudflareProvider(BaseProvider):
                     page = None
             if self.pagerules:
                 path = f'/zones/{zone_id}/pagerules'
-                resp = self._try_request('GET', path, params={'status': 'active'})
+                resp = self._try_request('GET', path,
+                                         params={'status': 'active'})
                 for r in resp['result']:
                     # assumption, base on API guide, will only contain 1 action
                     if r['actions'][0]['id'] == 'forwarding_url':

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -47,9 +47,9 @@ class CloudflareProvider(BaseProvider):
     MIN_TTL = 120
     TIMEOUT = 15
 
-    def __init__(self, id, email=None, token=None, cdn=False, retry_count=4,
-                 retry_period=300, zones_per_page=50, records_per_page=100,
-                 *args, **kwargs):
+    def __init__(self, id, email=None, token=None, cdn=False, pagerules=True,
+                retry_count=4, retry_period=300, zones_per_page=50,
+                records_per_page=100, *args, **kwargs):
         self.log = getLogger(f'CloudflareProvider[{id}]')
         self.log.debug('__init__: id=%s, email=%s, token=***, cdn=%s', id,
                        email, cdn)
@@ -68,6 +68,7 @@ class CloudflareProvider(BaseProvider):
                 'Authorization': f'Bearer {token}',
             })
         self.cdn = cdn
+        self.pagerules = pagerules
         self.retry_count = retry_count
         self.retry_period = retry_period
         self.zones_per_page = zones_per_page
@@ -76,6 +77,9 @@ class CloudflareProvider(BaseProvider):
 
         self._zones = None
         self._zone_records = {}
+        if not self.pagerules:
+            self.SUPPORTS = set(('ALIAS', 'A', 'AAAA', 'CAA', 'CNAME', 'LOC', 'MX', 'NS',
+                    'PTR', 'SRV', 'SPF', 'TXT'))
 
     def _try_request(self, *args, **kwargs):
         tries = self.retry_count
@@ -286,13 +290,13 @@ class CloudflareProvider(BaseProvider):
                     page += 1
                 else:
                     page = None
-
-            path = f'/zones/{zone_id}/pagerules'
-            resp = self._try_request('GET', path, params={'status': 'active'})
-            for r in resp['result']:
-                # assumption, base on API guide, will only contain 1 action
-                if r['actions'][0]['id'] == 'forwarding_url':
-                    records += [r]
+            if self.pagerules:
+                path = f'/zones/{zone_id}/pagerules'
+                resp = self._try_request('GET', path, params={'status': 'active'})
+                for r in resp['result']:
+                    # assumption, base on API guide, will only contain 1 action
+                    if r['actions'][0]['id'] == 'forwarding_url':
+                        records += [r]
 
             self._zone_records[zone.name] = records
 
@@ -609,7 +613,7 @@ class CloudflareProvider(BaseProvider):
     def _apply_Create(self, change):
         new = change.new
         zone_id = self.zones[new.zone.name]
-        if new._type == 'URLFWD':
+        if new._type == 'URLFWD' and self.pagerules:
             path = f'/zones/{zone_id}/pagerules'
         else:
             path = f'/zones/{zone_id}/dns_records'
@@ -713,7 +717,7 @@ class CloudflareProvider(BaseProvider):
         # otherwise required, just makes things deterministic
 
         # Creates
-        if _type == 'URLFWD':
+        if _type == 'URLFWD' and self.pagerules:
             path = f'/zones/{zone_id}/pagerules'
         else:
             path = f'/zones/{zone_id}/dns_records'
@@ -726,7 +730,7 @@ class CloudflareProvider(BaseProvider):
             record_id = info['record_id']
             data = info['data']
             old_data = info['old_data']
-            if _type == 'URLFWD':
+            if _type == 'URLFWD' and self.pagerules:
                 path = f'/zones/{zone_id}/pagerules/{record_id}'
             else:
                 path = f'/zones/{zone_id}/dns_records/{record_id}'
@@ -738,7 +742,7 @@ class CloudflareProvider(BaseProvider):
         for _, info in sorted(deletes.items()):
             record_id = info['record_id']
             old_data = info['data']
-            if _type == 'URLFWD':
+            if _type == 'URLFWD' and self.pagerules:
                 path = f'/zones/{zone_id}/pagerules/{record_id}'
             else:
                 path = f'/zones/{zone_id}/dns_records/{record_id}'
@@ -753,7 +757,7 @@ class CloudflareProvider(BaseProvider):
         existing_type = 'CNAME' if existing._type == 'ALIAS' \
             else existing._type
         for record in self.zone_records(existing.zone):
-            if 'targets' in record:
+            if 'targets' in record and self.pagerules:
                 uri = record['targets'][0]['constraint']['value']
                 uri = '//' + uri if not uri.startswith('http') else uri
                 parsed_uri = urlsplit(uri)

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -339,6 +339,9 @@ class CloudflareProvider(BaseProvider):
             values = defaultdict(lambda: defaultdict(list))
             for record in records:
                 if 'targets' in record:
+                    # We shouldn't get in here when pagerules are disabled as
+                    # we won't make the call to fetch the details/them
+                    #
                     # assumption, targets will always contain 1 target
                     # API documentation only indicates 'url' as the only target
                     # if record['targets'][0]['target'] == 'url':


### PR DESCRIPTION
As octodns only allows to manage a certain type of page-rules it's nice to have the option to disable it. 

For example we use Terraform to manage page-rules. 