### PR TITLE
Explicit strict_supports in tests

### DIFF
--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -219,7 +219,9 @@ class TestCloudflareProvider(TestCase):
         self.assertEqual(19, len(again.records))
 
     def test_apply(self):
-        provider = CloudflareProvider('test', 'email', 'token', retry_period=0)
+        provider = CloudflareProvider(
+            'test', 'email', 'token', retry_period=0, strict_supports=False
+        )
 
         provider._request = Mock()
 


### PR DESCRIPTION
As of https://github.com/octodns/octodns/pull/957 we'll need t be explicit in our tests around the expectations of `Provider.strict_supports`. This PR is in preparation of that change.

/cc https://github.com/octodns/octodns/pull/957