### PR TITLE
Version 0.0.2 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## v0.0.2 - 2022-??-?? -
+## v0.0.2 - 2022-12-25 - Holiday Edition
 
 * Added support for TLSA record type
-* switched to pytest and updated everything to latest template setup
+* Switched to pytest and updated everything to latest template setup
 
 ## v0.0.1 - 2022-01-05 - Moving
 

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -13,7 +13,7 @@ from octodns.record import Record, Update
 from octodns.provider import ProviderException
 from octodns.provider.base import BaseProvider
 
-__VERSION__ = '0.0.1'
+__VERSION__ = '0.0.2'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v0.0.2 - 2022-12-25 - Holiday Edition

* Added support for TLSA record type
* Switched to pytest and updated everything to latest template setup