### PR TITLE
SPF records can no longer be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.3 - 2022-??-?? -
+
+* SPF records can no longer be created,
+  https://github.com/octodns/octodns-cloudflare/issues/28
+
 ## v0.0.2 - 2022-12-25 - Holiday Edition
 
 * Added support for TLSA record type

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -9,8 +9,8 @@ from requests import Session
 from time import sleep
 from urllib.parse import urlsplit
 
-from octodns.record import Record, Update
-from octodns.provider import ProviderException
+from octodns.record import Create, Record, Update
+from octodns.provider import ProviderException, SupportsException
 from octodns.provider.base import BaseProvider
 
 __VERSION__ = '0.0.2'
@@ -455,6 +455,10 @@ class CloudflareProvider(BaseProvider):
         return exists
 
     def _include_change(self, change):
+        if isinstance(change, Create) and change.new._type == 'SPF':
+            msg = f'{self.id}: creating new SPF records not supported, use TXT instead'
+            raise SupportsException(msg)
+
         if isinstance(change, Update):
             new = change.new.data
 

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -149,10 +149,6 @@ ptr:
   ttl: 300
   type: PTR
   values: [foo.bar.com.]
-spf:
-  ttl: 600
-  type: SPF
-  value: v=spf1 ip4:192.168.0.1/16-all
 sub:
   type: 'NS'
   values:


### PR DESCRIPTION
TXT records should be used instead. See https://github.com/octodns/octodns-cloudflare/issues/28 for more details.

/cc Fixes https://github.com/octodns/octodns-cloudflare/issues/28