### PR TITLE
Fix fingerprint_type field name (just `type` in Cloudflare API) (#37)

### DIFF
--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -367,8 +367,8 @@ class CloudflareProvider(BaseProvider):
             )
             values.append(
                 {
-                    'algorithm': algorithm,
-                    'fingerprint_type': fingerprint_type,
+                    'algorithm': int(algorithm),
+                    'fingerprint_type': int(fingerprint_type),
                     'fingerprint': fingerprint,
                 }
             )
@@ -603,8 +603,8 @@ class CloudflareProvider(BaseProvider):
         for value in record.values:
             yield {
                 'data': {
-                    'algorithm': f'{value.algorithm}',
-                    'fingerprint_type': f'{value.fingerprint_type}',
+                    'algorithm': value.algorithm,
+                    'type': value.fingerprint_type,
                     'fingerprint': value.fingerprint,
                 }
             }
@@ -764,7 +764,7 @@ class CloudflareProvider(BaseProvider):
         elif _type == 'SSHFP':
             data = data['data']
             algorithm = data['algorithm']
-            fingerprint_type = data['fingerprint_type']
+            fingerprint_type = data['type']
             fingerprint = data['fingerprint']
             return f'{algorithm} {fingerprint_type} {fingerprint}'
         elif _type == 'TLSA':

--- a/tests/fixtures/cloudflare-dns_records-page-3.json
+++ b/tests/fixtures/cloudflare-dns_records-page-3.json
@@ -156,8 +156,8 @@
       "created_on": "2023-03-02T01:02:44.567985Z",
       "modified_on": "2023-03-02T01:02:44.567985Z",
       "data": {
-        "algorithm": "1",
-        "fingerprint_type": "2",
+        "algorithm": 1,
+        "type": 2,
         "fingerprint": "859be6ed04643db411f067b6c1da1d75fe08b672"
       },
       "meta": {

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -1992,8 +1992,8 @@ class TestCloudflareProvider(TestCase):
             'content': '1 2 859be6ed04643db411f067b6c1da1d75fe08b672',
             'created_on': '2023-03-02T01:02:44.567985Z',
             'data': {
-                'algorithm': '1',
-                'fingerprint_type': '2',
+                'algorithm': 1,
+                'type': 2,
                 'fingerprint': '859be6ed04643db411f067b6c1da1d75fe08b672',
             },
             'id': 'ggozrtnzb11nrr9qs4ko6y3j19qkehux9',
@@ -2021,8 +2021,8 @@ class TestCloudflareProvider(TestCase):
                 'type': 'SSHFP',
                 'values': [
                     {
-                        'algorithm': '1',
-                        'fingerprint_type': '2',
+                        'algorithm': 1,
+                        'fingerprint_type': 2,
                         'fingerprint': '859be6ed04643db411f067b6c1da1d75fe08b672',
                     }
                 ],


### PR DESCRIPTION
This commit fixes bug introduced in #38. 

An attempt to add `SSHFP` record
```
2023-03-02T15:58:17  [139982644081344] DEBUG CloudflareProvider[cloudflare] _request:   data={'data': {'algorithm': '1', 'fingerprint_type': '1', 'fingerprint': '859be6ed04643db411f067b6c1da1d75fe08b682'}, 'name': 'example.com', 'type': 'SSHFP', 'ttl': 3600}

```
would result into:
```
octodns_cloudflare.CloudflareError: DNS Validation Error
```
where the full error message looked like this:
```
{"result":null,"success":false,"errors":[{"code":1004,"message":"DNS Validation Error","error_chain":[{"code":9101,"message":"type is a required data field."}]}],"messages":[]}
```

Cloudflare stores `fingerprint` in uppercase letters, in case the fingerprint stored in YAML is in lower case it would result into a corrective change upon each run. 
```
  - type: SSHFP
    values:
      - algorithm: 1
        fingerprint: 859be6ed04643db411f067b6c1da1d75fe08b682
        fingerprint_type: 1
```
This can't be fixed in this repo. According to [RFC8174](https://www.rfc-editor.org/rfc/rfc8174.txt) only uppercase letter should be used. Probably a conversion to uppercase could be done in [sshfp class](https://github.com/octodns/octodns/blob/main/octodns/record/sshfp.py). 
