### PR TITLE
Handle utf-8 responses in domain names

### DIFF
--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -11,10 +11,10 @@ from urllib.parse import urlsplit
 from requests import Session
 
 from octodns import __VERSION__ as octodns_version
+from octodns.idna import IdnaDict
 from octodns.provider import ProviderException, SupportsException
 from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Update
-from octodns.idna import idna_decode
 
 __VERSION__ = '0.0.2'
 
@@ -175,7 +175,7 @@ class CloudflareProvider(BaseProvider):
                 else:
                     page = None
 
-            self._zones = {f'{idna_decode(z["name"])}.': z['id'] for z in zones}
+            self._zones = IdnaDict({f'{z["name"]}.': z['id'] for z in zones})
 
         return self._zones
 
@@ -380,8 +380,8 @@ class CloudflareProvider(BaseProvider):
         }
 
     def zone_records(self, zone):
-        if idna_decode(zone.name) not in self._zone_records:
-            zone_id = self.zones.get(idna_decode(zone.name), False)
+        if zone.name not in self._zone_records:
+            zone_id = self.zones.get(zone.name, False)
             if not zone_id:
                 return []
 
@@ -410,9 +410,9 @@ class CloudflareProvider(BaseProvider):
                     if r['actions'][0]['id'] == 'forwarding_url':
                         records += [r]
 
-            self._zone_records[idna_decode(zone.name)] = records
+            self._zone_records[zone.name] = records
 
-        return self._zone_records[idna_decode(zone.name)]
+        return self._zone_records[zone.name]
 
     def _record_for(self, zone, name, _type, records, lenient):
         # rewrite Cloudflare proxied records

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -14,6 +14,7 @@ from octodns import __VERSION__ as octodns_version
 from octodns.provider import ProviderException, SupportsException
 from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Update
+from octodns.idna import idna_decode
 
 __VERSION__ = '0.0.2'
 
@@ -174,7 +175,7 @@ class CloudflareProvider(BaseProvider):
                 else:
                     page = None
 
-            self._zones = {f'{z["name"]}.': z['id'] for z in zones}
+            self._zones = {f'{idna_decode(z["name"])}.': z['id'] for z in zones}
 
         return self._zones
 
@@ -379,8 +380,8 @@ class CloudflareProvider(BaseProvider):
         }
 
     def zone_records(self, zone):
-        if zone.name not in self._zone_records:
-            zone_id = self.zones.get(zone.name, False)
+        if idna_decode(zone.name) not in self._zone_records:
+            zone_id = self.zones.get(idna_decode(zone.name), False)
             if not zone_id:
                 return []
 
@@ -409,9 +410,9 @@ class CloudflareProvider(BaseProvider):
                     if r['actions'][0]['id'] == 'forwarding_url':
                         records += [r]
 
-            self._zone_records[zone.name] = records
+            self._zone_records[idna_decode(zone.name)] = records
 
-        return self._zone_records[zone.name]
+        return self._zone_records[idna_decode(zone.name)]
 
     def _record_for(self, zone, name, _type, records, lenient):
         # rewrite Cloudflare proxied records

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ),
         'test': tests_require,
     },
-    install_requires=('octodns>=0.9.14', 'requests>=2.27.0'),
+    install_requires=('octodns>=0.9.20', 'requests>=2.27.0'),
     license='MIT',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/fixtures/cloudflare-dns_records-page-1.json
+++ b/tests/fixtures/cloudflare-dns_records-page-1.json
@@ -178,9 +178,9 @@
   "result_info": {
     "page": 1,
     "per_page": 10,
-    "total_pages": 2,
+    "total_pages": 3,
     "count": 10,
-    "total_count": 20
+    "total_count": 27
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-dns_records-page-2.json
+++ b/tests/fixtures/cloudflare-dns_records-page-2.json
@@ -230,7 +230,7 @@
     "per_page": 10,
     "total_pages": 3,
     "count": 10,
-    "total_count": 24
+    "total_count": 27
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-dns_records-page-3.json
+++ b/tests/fixtures/cloudflare-dns_records-page-3.json
@@ -166,14 +166,31 @@
         "managed_by_argo_tunnel": false,
         "source": "primary"
       }
+    },
+    {
+      "id": "fc12ab34cd5612345422ab3322997664",
+      "type": "TXT",
+      "name": "txt.gíthub.com",
+      "content": "IDNA test data",
+      "proxiable": false,
+      "proxied": false,
+      "ttl": 600,
+      "locked": false,
+      "zone_id": "234234243423aaabb334342bbb343433",
+      "zone_name": "gíthub.com",
+      "modified_on": "2017-03-11T18:01:42.837282Z",
+      "created_on": "2017-03-11T18:01:42.837282Z",
+      "meta": {
+        "auto_added": false
+      }
     }
   ],
   "result_info": {
     "page": 3,
     "per_page": 10,
     "total_pages": 3,
-    "count": 6,
-    "total_count": 26
+    "count": 7,
+    "total_count": 27
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-zones-page-1.json
+++ b/tests/fixtures/cloudflare-zones-page-1.json
@@ -130,9 +130,9 @@
   "result_info": {
     "page": 1,
     "per_page": 2,
-    "total_pages": 2,
+    "total_pages": 3,
     "count": 2,
-    "total_count": 4
+    "total_count": 5
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-zones-page-2.json
+++ b/tests/fixtures/cloudflare-zones-page-2.json
@@ -130,9 +130,9 @@
   "result_info": {
     "page": 2,
     "per_page": 2,
-    "total_pages": 2,
+    "total_pages": 3,
     "count": 2,
-    "total_count": 4
+    "total_count": 5
   },
   "success": true,
   "errors": [],

--- a/tests/fixtures/cloudflare-zones-page-3.json
+++ b/tests/fixtures/cloudflare-zones-page-3.json
@@ -1,0 +1,77 @@
+{
+  "result": [
+    {
+      "id": "234234243423aaabb334342bbb343433",
+      "name": "gíthub.com",
+      "status": "pending",
+      "paused": false,
+      "type": "full",
+      "development_mode": 0,
+      "name_servers": [
+        "alice.ns.cloudflare.com",
+        "tom.ns.cloudflare.com"
+      ],
+      "original_name_servers": [],
+      "original_registrar": null,
+      "original_dnshost": null,
+      "modified_on": "2017-02-20T03:57:03.753292Z",
+      "created_on": "2017-02-20T03:53:59.274170Z",
+      "meta": {
+        "step": 4,
+        "wildcard_proxiable": false,
+        "custom_certificate_quota": 0,
+        "page_rule_quota": 3,
+        "phishing_detected": false,
+        "multiple_railguns_allowed": false
+      },
+      "owner": {
+        "type": "user",
+        "id": "334234243423aaabb334342aaa343433",
+        "email": "noreply@github.com"
+      },
+      "permissions": [
+        "#analytics:read",
+        "#billing:edit",
+        "#billing:read",
+        "#cache_purge:edit",
+        "#dns_records:edit",
+        "#dns_records:read",
+        "#lb:edit",
+        "#lb:read",
+        "#logs:read",
+        "#organization:edit",
+        "#organization:read",
+        "#ssl:edit",
+        "#ssl:read",
+        "#waf:edit",
+        "#waf:read",
+        "#zone:edit",
+        "#zone:read",
+        "#zone_settings:edit",
+        "#zone_settings:read"
+      ],
+      "plan": {
+        "id": "0feeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "name": "Free Website",
+        "price": 0,
+        "currency": "USD",
+        "frequency": "",
+        "is_subscribed": true,
+        "can_subscribe": false,
+        "legacy_id": "free",
+        "legacy_discount": false,
+        "externally_managed": false
+      }
+    }
+  ],
+  "result_info": {
+    "page": 3,
+    "per_page": 2,
+    "total_pages": 3,
+    "count": 1,
+    "total_count": 5
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -10,6 +10,7 @@ from requests import HTTPError
 from requests_mock import ANY
 from requests_mock import mock as requests_mock
 
+from octodns.idna import idna_encode
 from octodns.provider import SupportsException
 from octodns.provider.base import Plan
 from octodns.provider.yaml import YamlProvider
@@ -177,8 +178,10 @@ class TestCloudflareProvider(TestCase):
                 mock.get(f'{base}?page=1', status_code=200, text=fh.read())
             with open('tests/fixtures/cloudflare-zones-page-2.json') as fh:
                 mock.get(f'{base}?page=2', status_code=200, text=fh.read())
+            with open('tests/fixtures/cloudflare-zones-page-3.json') as fh:
+                mock.get(f'{base}?page=3', status_code=200, text=fh.read())
             mock.get(
-                f'{base}?page=3',
+                f'{base}?page=4',
                 status_code=200,
                 json={'result': [], 'result_info': {'count': 0, 'per_page': 0}},
             )
@@ -210,17 +213,17 @@ class TestCloudflareProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEqual(21, len(zone.records))
+            self.assertEqual(22, len(zone.records))
 
             changes = self.expected.changes(zone, provider)
 
             # delete a urlfwd, create 3 urlfwd, and create 1 spf
-            self.assertEqual(8, len(changes))
+            self.assertEqual(9, len(changes))
 
         # re-populating the same zone/records comes out of cache, no calls
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEqual(21, len(again.records))
+        self.assertEqual(22, len(again.records))
 
     def test_apply(self):
         provider = CloudflareProvider(
@@ -2037,3 +2040,33 @@ class TestCloudflareProvider(TestCase):
 
         key = provider._gen_key(cf_data)
         self.assertEqual('1 2 859be6ed04643db411f067b6c1da1d75fe08b672', key)
+
+    def test_idna_domain(self):
+        self.maxDiff = None
+        provider = CloudflareProvider('test', 'email', 'token')
+        # existing zone with data
+        with requests_mock() as mock:
+            base = 'https://api.cloudflare.com/client/v4/zones'
+            idna_zone_id='234234243423aaabb334342bbb343433'
+            # zone for idna zone is in page 3
+            with open('tests/fixtures/cloudflare-zones-page-3.json') as fh:
+                mock.get(f'{base}?page=1', status_code=200, text=fh.read())
+            # records for idna zone is in page 3
+            base = f'{base}/{idna_zone_id}'
+            with open(
+                'tests/fixtures/cloudflare-dns_records-page-3.json'
+            ) as fh:
+                mock.get(f'{base}/dns_records?page=1', status_code=200, text=fh.read())
+            # load page rules for idna zone
+            with open('tests/fixtures/cloudflare-pagerules.json') as fh:
+                mock.get(
+                    f'{base}/pagerules?status=active',
+                    status_code=200,
+                    text=fh.read(),
+                )
+
+            # notice the i is a utf-8 character which becomes `xn--gthub-zsa.com.`
+            zone = Zone('gíthub.com.', [])
+            provider.populate(zone)
+        self.assertEqual(8, len(zone.records))
+        self.assertEqual(zone.name, idna_encode('gíthub.com.'))

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -2047,7 +2047,7 @@ class TestCloudflareProvider(TestCase):
         # existing zone with data
         with requests_mock() as mock:
             base = 'https://api.cloudflare.com/client/v4/zones'
-            idna_zone_id='234234243423aaabb334342bbb343433'
+            idna_zone_id = '234234243423aaabb334342bbb343433'
             # zone for idna zone is in page 3
             with open('tests/fixtures/cloudflare-zones-page-3.json') as fh:
                 mock.get(f'{base}?page=1', status_code=200, text=fh.read())
@@ -2056,7 +2056,11 @@ class TestCloudflareProvider(TestCase):
             with open(
                 'tests/fixtures/cloudflare-dns_records-page-3.json'
             ) as fh:
-                mock.get(f'{base}/dns_records?page=1', status_code=200, text=fh.read())
+                mock.get(
+                    f'{base}/dns_records?page=1',
+                    status_code=200,
+                    text=fh.read(),
+                )
             # load page rules for idna zone
             with open('tests/fixtures/cloudflare-pagerules.json') as fh:
                 mock.get(


### PR DESCRIPTION
Cloudflare API will respond with UTF-8 encoded domain names instead of IDNA encoded domain names. This change normalizes the names in `self._zones` as the idna encoded name so that these domains are recognized and attempts to re-add won't happen.


fixes #42