### PR TITLE
Add AccountID filter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ providers:
     # Your Cloudflare account email address (required, optional if using token)
     email: env/CLOUDFLARE_EMAIL
     token: env/CLOUDFLARE_TOKEN
+    # Optional. Filter by account ID in environments where a token has access
+    # across more than the permitted number of accounts allowed by Cloudflare.
+    account_id: env/CLOUDFLARE_ACCOUNT_ID
     # Import CDN enabled records as CNAME to {}.cdn.cloudflare.net. Records
     # ending at .cdn.cloudflare.net. will be ignored when this provider is
     # not used as the source and the cdn option is enabled.

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -171,7 +171,7 @@ class CloudflareProvider(BaseProvider):
             while page:
                 params = {'page': page, 'per_page': self.zones_per_page}
                 if self.account_id is not None:
-                    params.update({'account.id': self.account_id})
+                    params['account.id'] = self.account_id
                 resp = self._try_request('GET', '/zones', params=params)
                 zones += resp['result']
                 info = resp['result_info']

--- a/script/coverage
+++ b/script/coverage
@@ -22,6 +22,7 @@ grep -r -I --line-number "# pragma: +no.*cover" $SOURCE_DIR && {
   exit 1
 }
 
+export CLOUDFLARE_ACCOUNT_ID=
 export CLOUDFLARE_EMAIL=
 export CLOUDFLARE_TOKEN=
 

--- a/script/test
+++ b/script/test
@@ -14,6 +14,7 @@ if [ ! -f "$ACTIVATE" ]; then
 fi
 . "$ACTIVATE"
 
+export CLOUDFLARE_ACCOUNT_ID=
 export CLOUDFLARE_EMAIL=
 export CLOUDFLARE_TOKEN=
 

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -1259,7 +1259,9 @@ class TestCloudflareProvider(TestCase):
             self.assertEqual(expected, provider._gen_key(data))
 
     def test_cdn(self):
-        provider = CloudflareProvider('test', 'email', 'token', True)
+        provider = CloudflareProvider(
+            'test', 'email', 'token', 'account_id', True
+        )
 
         # A CNAME for us to transform to ALIAS
         provider.zone_records = Mock(
@@ -1406,7 +1408,9 @@ class TestCloudflareProvider(TestCase):
         self.assertEqual(1, len(plan.changes))
 
     def test_cdn_alias(self):
-        provider = CloudflareProvider('test', 'email', 'token', True)
+        provider = CloudflareProvider(
+            'test', 'email', 'token', 'account_id', True
+        )
 
         # A CNAME for us to transform to ALIAS
         provider.zone_records = Mock(
@@ -2074,3 +2078,32 @@ class TestCloudflareProvider(TestCase):
             provider.populate(zone)
         self.assertEqual(8, len(zone.records))
         self.assertEqual(zone.name, idna_encode('gíthub.com.'))
+
+    def test_account_id_filter(self):
+        provider = CloudflareProvider(
+            'test',
+            'email',
+            'token',
+            account_id='334234243423aaabb334342aaa343433',
+        )
+
+        provider._request = Mock(status_code=200)
+        provider._request.side_effect = [
+            self.empty,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]
+
+        provider.plan(self.expected)
+        provider._request.assert_called_with(
+            'GET',
+            '/zones',
+            params={
+                'page': 1,
+                'per_page': 50,
+                'account.id': '334234243423aaabb334342aaa343433',
+            },
+        )

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -2085,6 +2085,7 @@ class TestCloudflareProvider(TestCase):
             'email',
             'token',
             account_id='334234243423aaabb334342aaa343433',
+            strict_supports=False,
         )
 
         provider._request = Mock(status_code=200)


### PR DESCRIPTION
Added the ability to filter by account ID in environments where a token has access across more than the permitted number for accounts allowed by Cloudflare.