### PR TITLE
v0.0.3 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
-## v0.0.3 - 2022-??-?? -
+## v0.0.3 - 2023-09-20 - All the commits fit to release
 
 * SPF records can no longer be created,
   https://github.com/octodns/octodns-cloudflare/issues/28
+* NAPTR and SSHFP support added
+* All HTTP requests include a meaningful user-agent.
+* AccountID filter support
+* API token auth method/doc
 
 ## v0.0.2 - 2022-12-25 - Holiday Edition
 

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider import ProviderException, SupportsException
 from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Update
 
-__VERSION__ = '0.0.2'
+__VERSION__ = '0.0.3'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v0.0.3 - 2023-09-20 - All the commits fit to release

* SPF records can no longer be created,
  https://github.com/octodns/octodns-cloudflare/issues/28
* NAPTR and SSHFP support added
* All HTTP requests include a meaningful user-agent.
* AccountID filter support
* API token auth method/doc

/cc Fixes https://github.com/octodns/octodns-cloudflare/issues/54