### PR TITLE
Make minimum TTL configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Support for auto-ttl without proxied as records can be configured that way,
   see auto-ttl in README.md for more info
 * Fix bug in handling of empty strings/content on TXT records
+* Make the minumum supported TTL configurable.
 
 ## v0.0.3 - 2023-09-20 - All the commits fit to release
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ providers:
     #zones_per_page: 50
     # Optional. Default: 100. Number of dns records per page.
     #records_per_page: 100
+    # Optional. Default: 120. Lowest TTL allowed to be set.
+    # A different limit for (non-)enterprise zone applies.
+    # See: https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl
+    #min_ttl: 120
 ```
 
 Note: The "proxied" flag of "A", "AAAA" and "CNAME" records can be managed via the YAML provider like so:
@@ -109,6 +113,11 @@ CloudflareProvider does not support dynamic records.
 #### Required API Token Permissions
 
 Required Permissions for API Token are Zone:Read, DNS:Read, and DNS:Edit.
+
+#### TTL
+
+Cloudflare has a different minimum TTL for enterprise and non-enterprise zones. See the [documentation](https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl) for more information.
+In the past the CloudflareProvider had a fixed minimum TTL set to 120 seconds and for backwards compatbility this is the current default.
 
 ### Developement
 

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -64,7 +64,6 @@ class CloudflareProvider(BaseProvider):
         )
     )
 
-    MIN_TTL = 120
     TIMEOUT = 15
 
     def __init__(
@@ -79,6 +78,7 @@ class CloudflareProvider(BaseProvider):
         retry_period=300,
         zones_per_page=50,
         records_per_page=100,
+        min_ttl=120,
         *args,
         **kwargs,
     ):
@@ -111,6 +111,7 @@ class CloudflareProvider(BaseProvider):
         self.retry_period = retry_period
         self.zones_per_page = zones_per_page
         self.records_per_page = records_per_page
+        self.min_ttl = min_ttl
         self._sess = sess
 
         self._zones = None
@@ -560,8 +561,8 @@ class CloudflareProvider(BaseProvider):
             # Cloudflare has a minimum TTL, we need to clamp the TTL values so
             # that we ignore a desired state (new) where we can't support the
             # TTL
-            new['ttl'] = max(self.MIN_TTL, new['ttl'])
-            existing['ttl'] = max(self.MIN_TTL, existing['ttl'])
+            new['ttl'] = max(self.min_ttl, new['ttl'])
+            existing['ttl'] = max(self.min_ttl, existing['ttl'])
 
             if new == existing:
                 return False
@@ -736,7 +737,7 @@ class CloudflareProvider(BaseProvider):
             # when either is the case we tell Cloudflare with ttl=1
             ttl = 1
         else:
-            ttl = max(self.MIN_TTL, record.ttl)
+            ttl = max(self.min_ttl, record.ttl)
 
         # Cloudflare supports ALIAS semantics with a root CNAME
         if _type == 'ALIAS':


### PR DESCRIPTION
This commit allows to set the `min_ttl` configuration option. The default is kept as the original 120 seconds.

resolves #76