### PR TITLE
v0.0.4 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.4 - 2023-??-?? - Know your zones
+## v0.0.4 - 2024-02-08 - Know your zones
 
 * Support for Provider.list_zones to enable dynamic zone config when operating
   as a source

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.3'
+__version__ = __VERSION__ = '0.0.4'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v0.0.4 - 2024-02-08 - Know your zones

* Support for Provider.list_zones to enable dynamic zone config when operating
  as a source
* Support for auto-ttl without proxied as records can be configured that way,
  see auto-ttl in README.md for more info
* Fix bug in handling of empty strings/content on TXT records
* Make the minumum supported TTL configurable.

/cc Fixes https://github.com/octodns/octodns-cloudflare/issues/79