### PR TITLE
Version 0.0.5 bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.4 - 2024-??-?? - ???
+## v0.0.5 - 2024-04-15 - Comment on your proxying and ttls
 
 * TtlToProxy processor added to enable the proxied flag based on a sentinel
   ttl value. Useful when the source is not YamlProvider

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.4'
+__version__ = __VERSION__ = '0.0.5'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v0.0.5 - 2024-04-15 - Comment on your proxying and ttls

* TtlToProxy processor added to enable the proxied flag based on a sentinel
  ttl value. Useful when the source is not YamlProvider
* Add support for comments & tags via octodns.cloudflare.comment|tags
* ProxyCNAME processor added to aid in supporting Cloudflare prixed values
  with non-Cloudflare DNS providers by directing them to the relevant
  .cdn.cloudflare.net. CNAME / ALIAS value.

/cc Fixes https://github.com/octodns/octodns-cloudflare/issues/90