### PR TITLE
Add support for DS record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.0.6 - 2024-??-?? - ???
 
 * Fix handling of unsupported record types during apply
+* DS record type support
 
 ## v0.0.5 - 2024-04-15 - Comment on your proxying and ttls
 

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -72,6 +72,14 @@ dname:
   ttl: 300
   type: DNAME
   value: unit.tests.
+ds:
+  ttl: 300
+  type: DS
+  value:
+    algorithm: 13
+    digest: "B5BB9D8014A0F9B1D61E21E796D78DCCDF1352F23CD32812F4850B878AE4944C"
+    digest_type: 2
+    key_tag: 1
 excluded:
   octodns:
     excluded:

--- a/tests/fixtures/cloudflare-dns_records-page-3.json
+++ b/tests/fixtures/cloudflare-dns_records-page-3.json
@@ -201,14 +201,14 @@
             "managed_by_argo_tunnel": false
         },
         "modified_on": "2024-05-20T19:27:04.707266Z",
-        "name": "ds.xormedia.com",
+        "name": "ds.unit.tests.",
         "proxiable": false,
         "proxied": false,
         "tags": [],
         "ttl": 300,
         "type": "DS",
         "zone_id": "0896a14115d694fe7ad10dd1ed282578",
-        "zone_name": "xormedia.com"
+        "zone_name": "unit.tests"
     }
   ],
   "result_info": {

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -240,7 +240,7 @@ class TestCloudflareProvider(TestCase):
 
             zone = Zone('unit.tests.', [])
             provider.populate(zone)
-            self.assertEqual(22, len(zone.records))
+            self.assertEqual(23, len(zone.records))
 
             changes = self.expected.changes(zone, provider)
 
@@ -250,7 +250,7 @@ class TestCloudflareProvider(TestCase):
         # re-populating the same zone/records comes out of cache, no calls
         again = Zone('unit.tests.', [])
         provider.populate(again)
-        self.assertEqual(22, len(again.records))
+        self.assertEqual(23, len(again.records))
 
     def test_apply(self):
         provider = CloudflareProvider(
@@ -264,12 +264,12 @@ class TestCloudflareProvider(TestCase):
             {'result': {'id': 42}},  # zone create
         ] + [
             None
-        ] * 30  # individual record creates
+        ] * 31  # individual record creates
 
         # non-existent zone, create everything
         plan = provider.plan(self.expected)
-        self.assertEqual(18, len(plan.changes))
-        self.assertEqual(18, provider.apply(plan))
+        self.assertEqual(19, len(plan.changes))
+        self.assertEqual(19, provider.apply(plan))
         self.assertFalse(plan.exists)
 
         provider._request.assert_has_calls(
@@ -333,7 +333,7 @@ class TestCloudflareProvider(TestCase):
             True,
         )
         # expected number of total calls
-        self.assertEqual(32, provider._request.call_count)
+        self.assertEqual(33, provider._request.call_count)
 
         provider._request.reset_mock()
 
@@ -575,12 +575,12 @@ class TestCloudflareProvider(TestCase):
             {'result': {'id': 42}},  # zone create
         ] + [
             None
-        ] * 30  # individual record creates
+        ] * 31  # individual record creates
 
         # non-existent zone, create everything
         plan = provider.plan(self.expected)
-        self.assertEqual(18, len(plan.changes))
-        self.assertEqual(18, provider.apply(plan))
+        self.assertEqual(19, len(plan.changes))
+        self.assertEqual(19, provider.apply(plan))
         self.assertFalse(plan.exists)
 
         provider._request.assert_has_calls(
@@ -648,7 +648,7 @@ class TestCloudflareProvider(TestCase):
             True,
         )
         # expected number of total calls
-        self.assertEqual(32, provider._request.call_count)
+        self.assertEqual(33, provider._request.call_count)
 
     def test_update_add_swap(self):
         provider = CloudflareProvider('test', 'email', 'token', retry_period=0)
@@ -2382,7 +2382,7 @@ class TestCloudflareProvider(TestCase):
             # notice the i is a utf-8 character which becomes `xn--gthub-zsa.com.`
             zone = Zone('gíthub.com.', [])
             provider.populate(zone)
-        self.assertEqual(8, len(zone.records))
+        self.assertEqual(9, len(zone.records))
         self.assertEqual(zone.name, idna_encode('gíthub.com.'))
 
     def test_account_id_filter(self):


### PR DESCRIPTION
Fairly simple add, bit of churn to update the tests to include the new record type.

/cc https://github.com/octodns/octodns-cloudflare/pull/95 @kkzo