### PR TITLE
Add DS support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ name:
 
 #### Records
 
-CloudflareProvider supports A, AAAA, ALIAS, CAA, CNAME, LOC, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, and URLFWD. There are restrictions on CAA tag support.
+CloudflareProvider supports A, AAAA, ALIAS, CAA, CNAME, DS, LOC, MX, NAPTR, NS, PTR, SPF, SRV, SSHFP, TXT, and URLFWD. There are restrictions on CAA tag support.
 
 #### Root NS Records
 


### PR DESCRIPTION
DS supported was added in [v0.0.6](https://github.com/octodns/octodns-cloudflare/commit/9641422c923cc3a6dee72e74d45bcb21e2e77c86). Updated README to match.