### PR TITLE
Create DS records after NS for the same node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Create DS records after their sibling NS records to appease Cloudflare's
   validations
+* Throw an error when trying to create a DS without a coresponding NS,
+  `strict_supports: false` will omit the DS instead
 
 ## v0.0.6 - 2024-05-22 - Deal with unknowns and make more knowns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.? - 2024-??-?? - ???
+
+* Create DS records after their sibling NS records to appease Cloudflare's
+  validations
+
 ## v0.0.6 - 2024-05-22 - Deal with unknowns and make more knowns
 
 * Fix handling of unsupported record types during apply

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -161,9 +161,13 @@ class CloudflareProvider(BaseProvider):
         return resp.json()
 
     def _change_keyer(self, change):
-        key = change.__class__.__name__
-        order = {'Delete': 0, 'Create': 1, 'Update': 2}
-        return order[key]
+        _type = change.record._type
+        if _type == 'DS' and isinstance(change, Create):
+            # when creating records in CF the NS for a node must come before the
+            # DS so we need to flip their order. when deleting they'll already
+            # be in the required order
+            _type = 'ZDS'
+        return (change.CLASS_ORDERING, change.record.name, _type)
 
     @property
     def zones(self):

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -73,13 +73,16 @@ dname:
   type: DNAME
   value: unit.tests.
 ds:
-  ttl: 300
-  type: DS
-  value:
-    algorithm: 13
-    digest: "B5BB9D8014A0F9B1D61E21E796D78DCCDF1352F23CD32812F4850B878AE4944C"
-    digest_type: 2
-    key_tag: 1
+  - ttl: 300
+    type: DS
+    value:
+      algorithm: 13
+      digest: "B5BB9D8014A0F9B1D61E21E796D78DCCDF1352F23CD32812F4850B878AE4944C"
+      digest_type: 2
+      key_tag: 1
+  - ttl: 301
+    type: NS
+    value: ns1.unit.tests.
 excluded:
   octodns:
     excluded:

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -2723,3 +2723,41 @@ class TestCloudflareProvider(TestCase):
             extra_changes[0].new._octodns['cloudflare']['comment'],
             'a new comment',
         )
+
+    def test_change_keyer(self):
+        provider = CloudflareProvider('test', 'email', 'token')
+
+        zone = Zone('unit.tests.', [])
+
+        ds = Record.new(
+            zone,
+            'subber',
+            {
+                'ttl': 300,
+                'type': 'DS',
+                'value': {
+                    'key_tag': 23,
+                    'algorithm': 2,
+                    'digest_type': 3,
+                    'digest': 'abcdefg',
+                },
+            },
+        )
+        self.assertEqual(
+            (1, 'subber', 'ZDS'), provider._change_keyer(Create(ds))
+        )
+        self.assertEqual(
+            (0, 'subber', 'DS'), provider._change_keyer(Delete(ds))
+        )
+
+        ns = Record.new(
+            zone,
+            'subber',
+            {'ttl': 300, 'type': 'NS', 'value': 'ns1.unit.tests.'},
+        )
+        self.assertEqual(
+            (1, 'subber', 'NS'), provider._change_keyer(Create(ns))
+        )
+        self.assertEqual(
+            (0, 'subber', 'NS'), provider._change_keyer(Delete(ns))
+        )


### PR DESCRIPTION
Cloudflare requires that DS records be created after the corresponding NS records (at the same node) 

This also means that you cannot create a standalone DS in Cloudflare, through other providers allow it.

/cc Fixes https://github.com/octodns/octodns-cloudflare/issues/102 @elidhu  