### PR TITLE
v0.0.7 changelog update & version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.? - 2024-??-?? - ???
+## v0.0.7 - 2024-08-20 - DS always come second
 
 * Create DS records after their sibling NS records to appease Cloudflare's
   validations

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Create, Record, Update
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.6'
+__version__ = __VERSION__ = '0.0.7'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v0.0.7 - 2024-08-20 - DS always come second

* Create DS records after their sibling NS records to appease Cloudflare's
  validations
* Throw an error when trying to create a DS without a coresponding NS,
  `strict_supports: false` will omit the DS instead

/cc Fixes https://github.com/octodns/octodns-cloudflare/issues/106