### PR TITLE
Add auto_ttl config parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ providers:
     # A different limit for (non-)enterprise zone applies.
     # See: https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl
     #min_ttl: 120
+    # Optional. Default: false. Set auto-ttl to true for all records by default.
+    #auto_ttl: false
 ```
 
 Note: The "proxied" flag of "A", "AAAA" and "CNAME" records can be managed via the YAML provider like so:

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -864,7 +864,12 @@ class CloudflareProvider(BaseProvider):
         return (
             not self._record_is_proxied(record)
             and not self.cdn
-            and record._octodns.get('cloudflare', {}).get('auto-ttl', record.source != self and record._type != 'URLFWD' and self.auto_ttl)
+            and record._octodns.get('cloudflare', {}).get(
+                'auto-ttl',
+                record.source != self
+                and record._type != 'URLFWD'
+                and self.auto_ttl,
+            )
         )
 
     def _record_comment(self, record):

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -94,6 +94,7 @@ class CloudflareProvider(BaseProvider):
         zones_per_page=50,
         records_per_page=100,
         min_ttl=120,
+        auto_ttl=False,
         *args,
         **kwargs,
     ):
@@ -127,6 +128,7 @@ class CloudflareProvider(BaseProvider):
         self.zones_per_page = zones_per_page
         self.records_per_page = records_per_page
         self.min_ttl = min_ttl
+        self.auto_ttl = auto_ttl
         self._sess = sess
 
         self._zones = None
@@ -862,7 +864,7 @@ class CloudflareProvider(BaseProvider):
         return (
             not self._record_is_proxied(record)
             and not self.cdn
-            and record._octodns.get('cloudflare', {}).get('auto-ttl', False)
+            and record._octodns.get('cloudflare', {}).get('auto-ttl', record.source != self and record._type != 'URLFWD' and self.auto_ttl)
         )
 
     def _record_comment(self, record):


### PR DESCRIPTION
The Cloudflare dashboard uses Auto TTL by default for new records. This change adds a config parameter to use auto-ttl: true for all records by default.