### PR TITLE
Mark only supported record types as proxied

### DIFF
--- a/octodns_cloudflare/processor/ttl.py
+++ b/octodns_cloudflare/processor/ttl.py
@@ -2,7 +2,7 @@
 #
 #
 
-from octodns.processor.base import BaseProcessor, ProcessorException
+from octodns.processor.base import BaseProcessor
 
 from octodns_cloudflare import _PROXIABLE_RECORD_TYPES
 

--- a/octodns_cloudflare/processor/ttl.py
+++ b/octodns_cloudflare/processor/ttl.py
@@ -36,14 +36,12 @@ class TtlToProxy(BaseProcessor):
     def process_source_zone(self, zone, *args, **kwargs):
         for record in zone.records:
             if record.ttl == self.ttl:
-                attr = {
-                    'auto-ttl': True,
-                }
+                attr = {'auto-ttl': True}
                 if record._type in _PROXIABLE_RECORD_TYPES:
-                    attr["proxied"] = True
+                    attr['proxied'] = True
 
                 record = record.copy()
-                record._octodns["cloudflare"] = attr
+                record._octodns['cloudflare'] = attr
                 record.ttl = 1
                 # Ensure we set to valid TTL.
                 zone.add_record(record, replace=True, lenient=True)

--- a/octodns_cloudflare/processor/ttl.py
+++ b/octodns_cloudflare/processor/ttl.py
@@ -4,6 +4,8 @@
 
 from octodns.processor.base import BaseProcessor, ProcessorException
 
+from octodns_cloudflare import _PROXIABLE_RECORD_TYPES
+
 
 class TtlToProxy(BaseProcessor):
     '''
@@ -34,11 +36,14 @@ class TtlToProxy(BaseProcessor):
     def process_source_zone(self, zone, *args, **kwargs):
         for record in zone.records:
             if record.ttl == self.ttl:
-                record = record.copy()
-                record._octodns['cloudflare'] = {
-                    'proxied': True,
+                attr = {
                     'auto-ttl': True,
                 }
+                if record._type in _PROXIABLE_RECORD_TYPES:
+                    attr["proxied"] = True
+
+                record = record.copy()
+                record._octodns["cloudflare"] = attr
                 record.ttl = 1
                 # Ensure we set to valid TTL.
                 zone.add_record(record, replace=True, lenient=True)

--- a/tests/test_octodns_provider_cloudflare_processor_ttl.py
+++ b/tests/test_octodns_provider_cloudflare_processor_ttl.py
@@ -16,10 +16,14 @@ class TestTtlToProxy(TestCase):
         with_ttl = Record.new(
             zone, 'good', {'type': 'A', 'ttl': 0, 'value': '1.2.3.4'}
         )
+        with_ttl_type_other = Record.new(
+            zone, 'ttl-only', {'type': 'TXT', 'ttl': 0, 'value': 'acme'}
+        )
         without_ttl = Record.new(
             zone, 'bad', {'type': 'A', 'ttl': 10, 'value': '1.2.3.4'}
         )
         zone.add_record(with_ttl)
+        zone.add_record(with_ttl_type_other)
         zone.add_record(without_ttl)
 
         expected_with = Record.new(
@@ -32,10 +36,21 @@ class TestTtlToProxy(TestCase):
                 '_octodns': {'cloudflare': {'proxied': True, 'auto-ttl': True}},
             },
         )
+        expected_with_ttl_only = Record.new(
+            zone,
+            'ttl-only',
+            {
+                'type': 'TXT',
+                'ttl': 0,
+                'value': '1.2.3.4',
+                '_octodns': {'cloudflare': {'auto-ttl': True}},
+            },
+        )
         expected_without = Record.new(
             zone, 'bad', {'type': 'A', 'ttl': 10, 'value': '1.2.3.4'}
         )
         zone_expected.add_record(expected_with)
+        zone_expected.add_record(expected_with_ttl_only)
         zone_expected.add_record(expected_without)
 
         added_proxy = processor.process_source_zone(zone)
@@ -45,6 +60,9 @@ class TestTtlToProxy(TestCase):
         self.assertEqual(
             {'cloudflare': {'proxied': True, 'auto-ttl': True}}, good._octodns
         )
+        ttl_only = next(r for r in added_proxy.records if r.name == 'ttl-only')
+        self.assertEqual(1, good.ttl)
+        self.assertEqual({'cloudflare': {'auto-ttl': True}}, ttl_only._octodns)
         bad = next(r for r in added_proxy.records if r.name == 'bad')
         self.assertEqual(10, bad.ttl)
         self.assertFalse('cloudflare' in bad._octodns)


### PR DESCRIPTION
Previously, when using the TTL processor, all records with an applicable TTL were marked as proxied. However, this caused changes to be repeated for record types that could not be proxied, such as TXT records. Now only supported record types are marked as proxied.