### PR TITLE
zone_id lookup fallback for deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.8 - 20??-??-?? - ???
+
+* Add a zone_id lookup fallback when deleting records
+
+
 ## v0.0.7 - 2024-08-20 - DS always come second
 
 * Create DS records after their sibling NS records to appease Cloudflare's

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -348,7 +348,6 @@ class TestCloudflareProvider(TestCase):
                     "proxied": False,
                     "ttl": 300,
                     "locked": False,
-                    "zone_id": "ff12ab34cd5611334422ab3322997650",
                     "zone_name": "unit.tests",
                     "modified_on": "2017-03-11T18:01:43.420689Z",
                     "created_on": "2017-03-11T18:01:43.420689Z",
@@ -509,10 +508,10 @@ class TestCloudflareProvider(TestCase):
                     'DELETE',
                     '/zones/42/pagerules/2a9141b18ffb0e6aed826050eec970b8',
                 ),
+                # this one used the zone_id lookup fallback, thus 42
                 call(
                     'DELETE',
-                    '/zones/ff12ab34cd5611334422ab3322997650/'
-                    'dns_records/fc12ab34cd5611334422ab3322997653',
+                    '/zones/42/dns_records/fc12ab34cd5611334422ab3322997653',
                 ),
                 call(
                     'DELETE',


### PR DESCRIPTION
Fallback for finding a record's `zone_id` when it's not in the record data.


/cc [troykelly](https://github.com/troykelly)
/cc fixes https://github.com/octodns/octodns-cloudflare/issues/118 which reported the issue
/cc closes https://github.com/octodns/octodns-cloudflare/pull/119 which contains a similar fix, but a number of unrelated changes as well