### PR TITLE
Add option to retry on auth errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.8 - 20??-??-?? - ???
+
+* Add support for optionally retrying requests that hit 403 errors
+
 ## v0.0.7 - 2024-08-20 - DS always come second
 
 * Create DS records after their sibling NS records to appease Cloudflare's

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ providers:
     # Optional. Default: 4. Number of times to retry if a 429 response
     # is received.
     #retry_count: 4
+    # Optional. Default: 0. Number of times to retry if a 403 response
+    # is received.
+    #auth_error_retry_count: 0
     # Optional. Default: 300. Number of seconds to wait before retrying.
     #retry_period: 300
     # Optional. Default: 50. Number of zones per page.


### PR DESCRIPTION
Sometimes the Cloudflare API will return a 403 response for a DNS record change request for seemingly no good reason. This behavior is difficult to reproduce reliably, as it seems to only happen when a large number (hundreds) of zones needs to be created from scratch.

This change makes it possible to create a large amount of zones without having to manually restart the process after random 403 responses.

Related to #108 