### PR TITLE
Add option to log name server information on apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ providers:
     # A different limit for (non-)enterprise zone applies.
     # See: https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl
     #min_ttl: 120
+    # Optional. Default: False. Log zone name servers on apply.
+    #log_name_servers: False
 ```
 
 Note: The "proxied" flag of "A", "AAAA" and "CNAME" records can be managed via the YAML provider like so:

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -258,14 +258,19 @@ class TestCloudflareProvider(TestCase):
 
     def test_apply(self):
         provider = CloudflareProvider(
-            'test', 'email', 'token', retry_period=0, strict_supports=False
+            'test',
+            'email',
+            'token',
+            retry_period=0,
+            strict_supports=False,
+            log_name_servers=True,
         )
 
         provider._request = Mock()
 
         provider._request.side_effect = [
             self.empty,  # no zones
-            {'result': {'id': 42}},  # zone create
+            {'result': {'id': 42, 'name_servers': ['foo']}},  # zone create
         ] + [
             None
         ] * 34  # individual record creates
@@ -576,7 +581,7 @@ class TestCloudflareProvider(TestCase):
 
         provider._request.side_effect = [
             self.empty,  # no zones
-            {'result': {'id': 42}},  # zone create
+            {'result': {'id': 42, 'name_servers': ['foo']}},  # zone create
         ] + [
             None
         ] * 34  # individual record creates
@@ -696,7 +701,7 @@ class TestCloudflareProvider(TestCase):
         provider._request.side_effect = [
             CloudflareRateLimitError('{}'),
             self.empty,  # no zones
-            {'result': {'id': 42}},  # zone create
+            {'result': {'id': 42, 'name_servers': ['foo']}},  # zone create
             None,
             None,
             None,
@@ -869,7 +874,7 @@ class TestCloudflareProvider(TestCase):
         provider._request.side_effect = [
             CloudflareRateLimitError('{}'),
             self.empty,  # no zones
-            {'result': {'id': 42}},  # zone create
+            {'result': {'id': 42, 'name_servers': ['foo']}},  # zone create
             None,
             None,
             None,
@@ -1005,7 +1010,7 @@ class TestCloudflareProvider(TestCase):
         # Set things up to preexist/mock as necessary
         zone = Zone('unit.tests.', [])
         # Stuff a fake zone id in place
-        provider._zones = {zone.name: '42'}
+        provider._zones = {zone.name: {'id': '42', 'name_servers': ['foo']}}
         provider._request = Mock()
         side_effect = [
             {


### PR DESCRIPTION
Enable logging zone name server information on apply. This makes managing new zones easier, as otherwise one has to go look up the name server information for the zone separately in order to configure the domain registrar side records.

The name server information is already present in the responses that the zone method receives, so adding it is easy enough. Downside is that a nested dict structure is required, which makes lookups a bit more complex.

The nested dict part might be a bit controversial, and I'm by no means a python dev, so any pointers on how to do this in a more elegant way I will gladly take!