### PR TITLE
feat: support setting a plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ providers:
     #cdn: false
     # Manage Page Rules (URLFWD) records
     # pagerules: true
+    # Optional. Define Cloudflare plan type for the zones. Default: free,
+    # options: free, enterprise
+    #plan_type: free
     # Optional. Default: 4. Number of times to retry if a 429 response
     # is received.
     #retry_count: 4

--- a/octodns_cloudflare/record.py
+++ b/octodns_cloudflare/record.py
@@ -1,0 +1,47 @@
+from octodns.record import Record
+
+
+class CloudflareZoneRecord(Record):
+    """
+    Custom record type for Cloudflare zone.
+
+    Supports updating the zone plan.
+    """
+
+    _type = 'CF_ZONE'
+    _value_type = dict
+
+    FREE_PLAN = 'free'
+
+    def __init__(self, zone, name, data, *args, **kwargs):
+        super().__init__(zone, name, data, *args, **kwargs)
+        self.value = data['value']
+
+    @classmethod
+    def validate(cls, _name, fqdn, data):
+        value = data['value']
+        if not isinstance(value, dict):
+            return [f'CF_ZONE value must be a dict, not {type(value)}']
+
+        if 'plan' not in value:
+            return ['CF_ZONE value must include "plan" key']
+
+        if not all(isinstance(v, str) for v in value.values()):
+            return ['CF_ZONE values must be strings']
+
+        return []
+
+    def _equality_tuple(self):
+        return (self.zone.name, self._type, self.name, self.value['plan'])
+
+    def changes(self, other, target):
+        if not isinstance(other, CloudflareZoneRecord):
+            return True
+        return other.value != self.value
+
+    def __repr__(self):
+        return f'CloudflareZoneRecord<{self.value}>'
+
+
+# Register the custom record type
+Record.register_type(CloudflareZoneRecord)

--- a/tests/test_octodns_record_cloudflare.py
+++ b/tests/test_octodns_record_cloudflare.py
@@ -1,0 +1,172 @@
+from unittest import TestCase
+
+from octodns.record import Record, ValidationError
+from octodns.zone import Zone
+
+from octodns_cloudflare.record import CloudflareZoneRecord
+
+
+class TestCloudflareZoneRecord(TestCase):
+    def test_cloudflare_zone_record(self):
+        # Test valid plan record creation
+        zone = Zone('unit.tests.', [])
+
+        record = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+
+        self.assertIsInstance(record, CloudflareZoneRecord)
+        self.assertEqual('CF_ZONE', record._type)
+        self.assertEqual({'plan': 'enterprise'}, record.value)
+
+        # Test validation errors
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                zone,
+                '_plan_update',
+                {
+                    'type': 'CF_ZONE',
+                    'ttl': 300,
+                    'value': 'invalid',  # Should be dict
+                },
+            )
+        self.assertTrue('_plan_update.unit.tests.' in str(ctx.exception))
+        self.assertTrue('must be a dict' in str(ctx.exception))
+
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                zone,
+                '_plan_update',
+                {'type': 'CF_ZONE', 'ttl': 300, 'value': {}},  # Missing 'plan'
+            )
+        self.assertTrue('_plan_update.unit.tests.' in str(ctx.exception))
+        self.assertTrue('must include "plan" key' in str(ctx.exception))
+
+        with self.assertRaises(ValidationError) as ctx:
+            Record.new(
+                zone,
+                '_plan_update',
+                {
+                    'type': 'CF_ZONE',
+                    'ttl': 300,
+                    'value': {'plan': 123},  # Invalid value type
+                },
+            )
+        self.assertTrue('_plan_update.unit.tests.' in str(ctx.exception))
+        self.assertTrue('must be strings' in str(ctx.exception))
+
+        # Test equality comparison
+        record1 = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+
+        record2 = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+
+        record3 = Record.new(
+            zone,
+            '_plan_update',
+            {
+                'type': 'CF_ZONE',
+                'ttl': 300,
+                'value': {'plan': 'business'},  # Different target plan
+            },
+        )
+
+        self.assertEqual(record1, record2)
+        self.assertNotEqual(record1, record3)
+
+        # Test comparison with non-CloudflareZoneRecord
+        other_record = Record.new(
+            zone, '_plan_update', {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'}
+        )
+        self.assertTrue(record1.changes(other_record, None))
+
+    def test_cloudflare_zone_record_repr(self):
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+        self.assertEqual(
+            "CloudflareZoneRecord<{'plan': 'enterprise'}>", repr(record)
+        )
+
+    def test_cloudflare_zone_record_changes(self):
+        zone = Zone('unit.tests.', [])
+
+        # Test changes with non-CloudflareZoneRecord
+        record = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+        other = Record.new(
+            zone, '_plan_update', {'type': 'A', 'ttl': 300, 'value': '1.2.3.4'}
+        )
+        self.assertTrue(record.changes(other, None))
+
+        # Test changes with same type but different values
+        other = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'pro'}},
+        )
+        self.assertTrue(record.changes(other, None))
+
+        # Test no changes with identical records
+        other = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+        self.assertFalse(record.changes(other, None))
+
+    def test_cloudflare_zone_record_equality(self):
+        zone = Zone('unit.tests.', [])
+        record1 = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+
+        # Same record
+        record2 = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+        self.assertEqual(record1, record2)
+
+        # Different plan
+        record3 = Record.new(
+            zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'pro'}},
+        )
+        self.assertNotEqual(record1, record3)
+
+        # Different name
+        record4 = Record.new(
+            zone,
+            'other_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+        self.assertNotEqual(record1, record4)
+
+        # Different zone
+        other_zone = Zone('other.tests.', [])
+        record5 = Record.new(
+            other_zone,
+            '_plan_update',
+            {'type': 'CF_ZONE', 'ttl': 300, 'value': {'plan': 'enterprise'}},
+        )
+        self.assertNotEqual(record1, record5)


### PR DESCRIPTION
This pull request introduces support for managing Cloudflare plan types within the `octodns_cloudflare` provider. The change is implemented using a custom record type.

Aligned with change of `_zones` structure from #122 

Key changes include:
* Added a new optional `plan_type` parameter to the `CloudflareProvider` class to specify the Cloudflare plan type (e.g., free, enterprise).
* Created a new custom record type `CloudflareZoneRecord` to support Cloudflare zone plan updates.
* Adjusted the `_apply_Create`, `_apply_Update`, and `_apply_Delete` methods to manage plan updates based on the new `CF_ZONE` record type. 
* Updated `README.md` to document the new `plan_type` option.