### PR TITLE
Version 0.0.8 bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.8 - 20??-??-?? - ???
+## v0.0.8 - 2025-02-06 - More options
 
 * Add support for optionally retrying requests that hit 403 errors
 * Add a zone_id lookup fallback when deleting records

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
     SUPPORTS_SVCB = False
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.7'
+__version__ = __VERSION__ = '0.0.8'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v0.0.8 - 2025-02-06 - More options

* Add support for optionally retrying requests that hit 403 errors
* Add a zone_id lookup fallback when deleting records
* Add support for setting Cloudflare plan type for zones