### PR TITLE
Fully chunk and quote TXT values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.10 - 2025-??-?? - ???
+
+* Correctly quote and chunk TXT records to match Cloudflare's internal behavior
+
 ## v0.0.9 - 2025-02-06 - Unknown nameservers are a thing
 
 * Handle cases where Cloudflare doesn't return a zones name servers.

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -760,11 +760,8 @@ class CloudflareProvider(BaseProvider):
             }
 
     def _contents_for_TXT(self, record):
-        for value in record.values:
-            content = value.replace('\\;', ';')
-            if not value.startswith('"') and not value.endswith('"'):
-                content = f'"{content}"'
-            yield {'content': content}
+        for chunked in record.chunked_values:
+            yield {'content': chunked.replace('\\;', ';')}
 
     def _contents_for_CNAME(self, record):
         yield {'content': record.value}

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -1564,10 +1564,13 @@ class TestCloudflareProvider(TestCase):
         data = list(provider._contents_for_TXT(record))
         self.assertEqual([{'content': '"test-value-without-quotes"'}], data)
 
-        # Update value within record to allow testing with quotes
-        record.values[0] = '"test-value-with-quotes"'
-        data = list(provider._contents_for_TXT(record))
-        self.assertEqual([{'content': '"test-value-with-quotes"'}], data)
+        # really long txt value
+        txt = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+        zone = Zone('unit.tests.', [])
+        record = Record.new(zone, '', {'type': 'TXT', 'ttl': 300, 'value': txt})
+        chunked = record.chunked_values[0]
+        data = next(provider._contents_for_TXT(record))
+        self.assertEqual({'content': chunked}, data)
 
     def test_alias(self):
         provider = CloudflareProvider('test', 'email', 'token')


### PR DESCRIPTION
This matches Cloudflare's behavior where it will automatically quote and chunk values pushed to its api as needed.

/cc https://github.com/octodns/octodns-cloudflare/pull/134 which is related and did half this work