### PR TITLE
Fix _process_desired_zone bug

### DIFF
--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -727,7 +727,7 @@ class CloudflareProvider(BaseProvider):
                 self.supports_warn_or_except(msg, fallback)
                 desired.remove_record(record)
 
-        return desired
+        return super()._process_desired_zone(desired)
 
     def _contents_for_multiple(self, record):
         for value in record.values:

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -68,10 +68,6 @@ cname:
   ttl: 300
   type: CNAME
   value: unit.tests.
-dname:
-  ttl: 300
-  type: DNAME
-  value: unit.tests.
 ds:
   - ttl: 300
     type: DS

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -4,7 +4,7 @@
 
 from os.path import dirname, join
 from unittest import TestCase, skipIf
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 from requests import HTTPError
 from requests_mock import ANY
@@ -3088,7 +3088,13 @@ class TestCloudflareProvider(TestCase):
             (0, 'subber', 'NS'), provider._change_keyer(Delete(ns))
         )
 
-    def test_process_desired_zone(self):
+    @patch('octodns_cloudflare.BaseProvider._process_desired_zone')
+    def test_process_desired_zone(self, mock_base_process_desired_zone):
+        def mock_base_process_desired_zone_impl(desired):
+            desired._base_process_desired_zone = True
+            return desired
+        mock_base_process_desired_zone.side_effect = mock_base_process_desired_zone_impl
+
         provider = CloudflareProvider(
             'test', 'email', 'token', strict_supports=False
         )
@@ -3119,19 +3125,31 @@ class TestCloudflareProvider(TestCase):
         desired = zone.copy()
         desired.add_record(ds)
         desired.add_record(ns)
+        result = provider._process_desired_zone(desired)
+        mock_base_process_desired_zone.assert_called_once_with(desired)
+        mock_base_process_desired_zone.reset_mock()
+        self.assertTrue(result._base_process_desired_zone)
         self.assertEqual(
-            {ds, ns}, provider._process_desired_zone(desired).records
+            {ds, ns}, result.records
         )
 
         # just NS
         desired = zone.copy()
         desired.add_record(ns)
-        self.assertEqual({ns}, provider._process_desired_zone(desired).records)
+        result = provider._process_desired_zone(desired)
+        mock_base_process_desired_zone.assert_called_once_with(desired)
+        mock_base_process_desired_zone.reset_mock()
+        self.assertTrue(result._base_process_desired_zone)
+        self.assertEqual({ns}, result.records)
 
         # just DS, will be removed
         desired = zone.copy()
         desired.add_record(ds)
-        self.assertEqual(set(), provider._process_desired_zone(desired).records)
+        result = provider._process_desired_zone(desired)
+        mock_base_process_desired_zone.assert_called_once_with(desired)
+        mock_base_process_desired_zone.reset_mock()
+        self.assertTrue(result._base_process_desired_zone)
+        self.assertEqual(set(), result.records)
 
         # when in strict mode will error
         provider.strict_supports = True
@@ -3140,6 +3158,7 @@ class TestCloudflareProvider(TestCase):
         with self.assertRaises(SupportsException) as ctx:
             provider._process_desired_zone(desired)
         msg = str(ctx.exception)
+        mock_base_process_desired_zone.assert_not_called()
         self.assertTrue('subber.unit.tests.' in msg)
         self.assertTrue('coresponding NS record' in msg)
 


### PR DESCRIPTION
In `0.0.7`, an override was introduced for the `_process_desired_zone` hook. `octodns.provider.base.BaseProvider` requires Providers that override this method call their `super` implementation (see [docstring](https://github.com/octodns/octodns/blob/100c2959036c5ffcecbbc8ed7d21b745d086f38e/octodns/provider/base.py#L41-L43)), but `CloudflareProvider`'s implementation does not do so. `BaseProvider`'s implementation has a lot of sanity checking and cleanup logic for the desired zone, which has effectively been skipped by `CloudflareProvider` since `0.0.7` as a result of this bug.

This change fixes the issue by simply passing `desired` to the `super` implementation and returning the result.

Also included in this change:
* Removed the `DNAME` record from the test config -- now that `BaseProvider._process_desired_zone` is called as a result of this change, the presence of this `DNAME` record causes `SupportsException` to be raised when `strict_supports=True` (the default), breaking 2 tests: `test_apply` and `test_meta`.
* Updated the `_process_desired_zone` test to ensure the `super` implementation is called and the resulting `desired` is returned