### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:
 

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
     SUPPORTS_SVCB = False
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.9'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## v1.0.0 - 2025-05-03 - Long overdue 1.0

Noteworthy Changes:

* Complete removal of SPF record support, records should be transitioned to TXT
  values before updating to this version.

Changes:

* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
* Correctly quote and chunk TXT records to match Cloudflare's internal behavior

