### PR TITLE
Remove usage of zone_id from record when deleting

### DIFF
--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -1018,6 +1018,9 @@ class CloudflareProvider(BaseProvider):
         existing_name = existing.fqdn[:-1]
         # Make sure to map ALIAS to CNAME when looking for the target to delete
         existing_type = 'CNAME' if existing._type == 'ALIAS' else existing._type
+
+        zone_id = self.zones.get(existing.zone.name, False)
+
         for record in self.zone_records(existing.zone):
             if 'targets' in record and self.pagerules:
                 uri = record['targets'][0]['constraint']['value']
@@ -1025,7 +1028,6 @@ class CloudflareProvider(BaseProvider):
                 parsed_uri = urlsplit(uri)
                 record_name = parsed_uri.netloc
                 record_type = 'URLFWD'
-                zone_id = self.zones.get(existing.zone.name, False)
                 if (
                     existing_name == record_name
                     and existing_type == record_type
@@ -1038,7 +1040,7 @@ class CloudflareProvider(BaseProvider):
                     and existing_type == record['type']
                 ):
                     path = (
-                        f'/zones/{record["zone_id"]}/dns_records/'
+                        f'/zones/{zone_id}/dns_records/'
                         f'{record["id"]}'
                     )
                     self._try_request('DELETE', path)


### PR DESCRIPTION
This was deprecated a while ago https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2024-11-30.

Related to https://github.com/octodns/octodns-cloudflare/issues/140