### PR TITLE
Add configurable timeout parameter for API requests

### DIFF
--- a/.changelog/b4bf1480c7e948bf8eb2cbc059146750.md
+++ b/.changelog/b4bf1480c7e948bf8eb2cbc059146750.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+Add configurable timeout parameter for API requests

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ providers:
     # A different limit for (non-)enterprise zone applies.
     # See: https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl
     #min_ttl: 120
+    # Optional. Default: 15. Timeout in seconds for API requests.
+    #timeout: 15
 ```
 
 Note: The "proxied" flag of "A", "AAAA" and "CNAME" records can be managed via the YAML provider like so:

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -104,6 +104,7 @@ class CloudflareProvider(BaseProvider):
         zones_per_page=50,
         records_per_page=100,
         min_ttl=120,
+        timeout=TIMEOUT,
         *args,
         **kwargs,
     ):
@@ -140,6 +141,7 @@ class CloudflareProvider(BaseProvider):
         self.zones_per_page = zones_per_page
         self.records_per_page = records_per_page
         self.min_ttl = min_ttl
+        self.timeout = timeout
         self._sess = sess
 
         self._zones = None
@@ -196,7 +198,7 @@ class CloudflareProvider(BaseProvider):
 
         url = f'https://api.cloudflare.com/client/v4{path}'
         resp = self._sess.request(
-            method, url, params=params, json=data, timeout=self.TIMEOUT
+            method, url, params=params, json=data, timeout=self.timeout
         )
         self.log.debug('_request:   status=%d', resp.status_code)
         if resp.status_code == 400:


### PR DESCRIPTION
Add optional timeout parameter to CloudflareProvider to allow users to configure the request timeout. This is particularly useful for large zones where API requests may take longer than the default 15 seconds.

Changes:
- Add timeout parameter to __init__() with default of None
- Use self.timeout in _request() instead of hardcoded self.TIMEOUT
- Falls back to TIMEOUT class variable (15s) if not specified
- Document timeout parameter in README

Backward compatible - default behavior unchanged.