### PR TITLE
Version 1.1.0 bump & changelog update

### DIFF
--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/1679fe2619a74acc9b167fe5c2ee64b6.md
+++ b/.changelog/1679fe2619a74acc9b167fe5c2ee64b6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/3e79bd180b03441cb698d239e3a7d9b7.md
+++ b/.changelog/3e79bd180b03441cb698d239e3a7d9b7.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add ability to configure api_url

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/497dc7b1da634ffab00583eed179f3f5.md
+++ b/.changelog/497dc7b1da634ffab00583eed179f3f5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/9134dcf31fba4d8cabbf210112b1566d.md
+++ b/.changelog/9134dcf31fba4d8cabbf210112b1566d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/abb76fcfb3c24ef5a89461a33cd8d6c2.md
+++ b/.changelog/abb76fcfb3c24ef5a89461a33cd8d6c2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/b4bf1480c7e948bf8eb2cbc059146750.md
+++ b/.changelog/b4bf1480c7e948bf8eb2cbc059146750.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add configurable timeout parameter for API requests

--- a/.changelog/c773113b71564d178643c550bc8a75ce.md
+++ b/.changelog/c773113b71564d178643c550bc8a75ce.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/c96e476770684401a7f00973fee238d2.md
+++ b/.changelog/c96e476770684401a7f00973fee238d2.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ecc8f1ed6e674b15a4f2210dc828dd21.md
+++ b/.changelog/ecc8f1ed6e674b15a4f2210dc828dd21.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/f15880e897474a78b530ef4848aec672.md
+++ b/.changelog/f15880e897474a78b530ef4848aec672.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/.changelog/f54954f606c3480481aaae9c6dbac58e.md
+++ b/.changelog/f54954f606c3480481aaae9c6dbac58e.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add TagAllowListFilter and TagRejectListFilter processors to enable including/ignoring records based on Cloudflare tagging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.1.0 - 2026-04-03
+
+Minor:
+* Add ability to configure api_url - [#165](https://github.com/octodns/octodns-cloudflare/pull/165)
+* Add configurable timeout parameter for API requests - [#156](https://github.com/octodns/octodns-cloudflare/pull/156)
+* Add TagAllowListFilter and TagRejectListFilter processors to enable including/ignoring records based on Cloudflare tagging - [#149](https://github.com/octodns/octodns-cloudflare/pull/149)
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#148](https://github.com/octodns/octodns-cloudflare/pull/148)
+
 ## v1.0.0 - 2025-05-03 - Long overdue 1.0
 
 Noteworthy Changes:

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
     SUPPORTS_SVCB = False
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.1.0'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## 1.1.0 - 2026-04-03

Minor:
* Add ability to configure api_url - [#165](https://github.com/octodns/octodns-cloudflare/pull/165)
* Add configurable timeout parameter for API requests - [#156](https://github.com/octodns/octodns-cloudflare/pull/156)
* Add TagAllowListFilter and TagRejectListFilter processors to enable including/ignoring records based on Cloudflare tagging - [#149](https://github.com/octodns/octodns-cloudflare/pull/149)

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#148](https://github.com/octodns/octodns-cloudflare/pull/148)

