### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/882f01f417d44bfa975690e958a2d8b6.md
+++ b/.changelog/882f01f417d44bfa975690e958a2d8b6.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -176,7 +176,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -69,7 +69,9 @@ def set_record_tags(record, tags):
 
 class TestCloudflareProvider(TestCase):
     expected = Zone('unit.tests.', [])
-    source = YamlProvider('test', join(dirname(__file__), 'config'))
+    source = YamlProvider(
+        'test', join(dirname(__file__), 'config'), escaped_semicolons=False
+    )
     source.populate(expected)
 
     # Our test suite differs a bit, add our NS and remove the simple one

--- a/tests/test_octodns_provider_cloudflare_processor_proxycname.py
+++ b/tests/test_octodns_provider_cloudflare_processor_proxycname.py
@@ -132,7 +132,7 @@ class TestProxyCNAME(TestCase):
         self.assertEqual(zone_expected_cf.records, processed_cf_desired.records)
 
         # Process / check other provider destined records
-        yaml_provider = YamlProvider('test', 'test')
+        yaml_provider = YamlProvider('test', 'test', escaped_semicolons=False)
         processed_other_desired, processed_other_existing = (
             processor.process_source_and_target_zones(
                 zone, zone_empty, yaml_provider


### PR DESCRIPTION
YamlProvider is going to default to `escaped_semicolons=False` in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419