### PR TITLE
Version 1.2.0 bump & changelog update

### DIFF
--- a/.changelog/882f01f417d44bfa975690e958a2d8b6.md
+++ b/.changelog/882f01f417d44bfa975690e958a2d8b6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Explicit non-escaped semicolons for YamlProvider

--- a/.changelog/8ba9a13045834d4794ffc25675cee1df.md
+++ b/.changelog/8ba9a13045834d4794ffc25675cee1df.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Fix SSHFP fingerprint type and length mismatches

--- a/.changelog/97a6be116a00414ba56a0d1eba1d3323.md
+++ b/.changelog/97a6be116a00414ba56a0d1eba1d3323.md
@@ -1,4 +1,0 @@
----
-type: minor
----
-Add CloudflareInternalProvider for Cloudflare Internal DNS zones (type=internal); supports record management in pre-existing internal zones with optional view_id filter. See #170.

--- a/.changelog/b35581dfc88b45ae9be36e652b0b3ed6.md
+++ b/.changelog/b35581dfc88b45ae9be36e652b0b3ed6.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0 - 2026-06-19
+
+Minor:
+* Add CloudflareInternalProvider for Cloudflare Internal DNS zones (type=internal); supports record management in pre-existing internal zones with optional view_id filter. See #170. - [#171](https://github.com/octodns/octodns-cloudflare/pull/171)
+
 ## 1.1.0 - 2026-04-03
 
 Minor:

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -25,7 +25,7 @@ except ImportError:  # pragma: no cover
     SUPPORTS_SVCB = False
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.1.0'
+__version__ = __VERSION__ = '1.2.0'
 
 
 class CloudflareError(ProviderException):


### PR DESCRIPTION
## 1.2.0 - 2026-06-19

Minor:
* Add CloudflareInternalProvider for Cloudflare Internal DNS zones (type=internal); supports record management in pre-existing internal zones with optional view_id filter. See #170. - [#171](https://github.com/octodns/octodns-cloudflare/pull/171)

