### PR TITLE
Add per-value comment/tags support (octodns.cloudflare.values)

### DIFF
--- a/.changelog/a3d62a16f9c343ae8be46e34962cb4d7.md
+++ b/.changelog/a3d62a16f9c343ae8be46e34962cb4d7.md
@@ -1,0 +1,4 @@
+---
+type: minor
+---
+CloudflareProvider can now manage Cloudflare per-value (per-object) `comment` and `tags` via an optional `values` list under `octodns.cloudflare`, keyed by value. Records whose values carry differing comment/tags are now dumped and applied without losing metadata; the record-level `comment`/`tags` remain as a default for values without an entry, and a value's entry is a clean override. Per-value entries that reference a value not on the record are reported at plan time via `strict_supports`. The `TagAllowListFilter`/`TagRejectListFilter` processors now match on per-value tags as well as record-level tags. See #142.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,56 @@ name:
     value: 1.2.3.4
 ```
 
+Note: Cloudflare stores `comment` and `tags` on each individual DNS object — that is, per *value*. The record-level `comment`/`tags` above are applied to every value of a record. To set them per value, add a `values` list under `octodns.cloudflare`, where each entry names a `value` (in the same form it appears in the record's `values`) and its own `comment` and/or `tags`:
+
+```yaml
+multi:
+    octodns:
+        cloudflare:
+            comment: "default applied to values without an entry"
+            tags:
+              - "team:web"
+            values:
+              - value: 1.2.3.5
+                comment: "failover box"
+                tags:
+                  - "team:web"
+                  - "deprecated"
+    ttl: 300
+    type: A
+    values:
+      - 1.2.3.4   # uses the record-level comment/tags above
+      - 1.2.3.5   # uses its own entry
+```
+
+A value's entry is a clean override: a `comment`/`tags` it specifies replaces the record-level one for that value (tags are not merged), while a field it omits falls back to the record level. Records whose values all share the same metadata keep the simpler record-level form shown earlier. Structured-value types work the same way — the entry's `value` is the structured form, e.g. for `MX`:
+
+```yaml
+'':
+    octodns:
+        cloudflare:
+            values:
+              - value:
+                  preference: 10
+                  exchange: mx1.example.com.
+                comment: "primary MX"
+              - value:
+                  preference: 20
+                  exchange: mx2.example.com.
+                comment: "backup MX"
+    ttl: 300
+    type: MX
+    values:
+      - preference: 10
+        exchange: mx1.example.com.
+      - preference: 20
+        exchange: mx2.example.com.
+```
+
+A per-value entry whose `value` does not match any of the record's values is reported at plan time (raised under `strict_supports`, otherwise warned), as is a malformed `values` list. Cloudflare can hold two objects with the same value but different metadata, which can't be represented per-value; in that case the first is kept and a warning is logged on dump.
+
+The `TagAllowListFilter`/`TagRejectListFilter` [processors](#processors) consider a record's per-value tags as well as its record-level tags — a record is treated as carrying a tag if any of its values do.
+
 Note: `A`, `AAAA`, `CNAME` and `ALIAS` records support a Cloudflare [Regional Services](https://developers.cloudflare.com/data-localization/regional-services/) (Data Localization) `region`. The value is the Cloudflare `region_key` (e.g. `eu`, `isoeu`, `us`, `ca`, …).
 
 This is **opt-in**: set `regional_services: true` on the provider to enable it. When disabled (the default), the provider never calls the regional services API — no behaviour change and no extra request for existing users. This matters because Regional Services is an Enterprise add-on and the API errors for accounts without the entitlement.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ A value's entry is a clean override: a `comment`/`tags` it specifies replaces th
         exchange: mx2.example.com.
 ```
 
-A per-value entry whose `value` does not match any of the record's values is reported at plan time (raised under `strict_supports`, otherwise warned), as is a malformed `values` list. Cloudflare can hold two objects with the same value but different metadata, which can't be represented per-value; in that case the first is kept and a warning is logged on dump.
+A per-value entry whose `value` does not match any of the record's values is reported at plan time (raised under `strict_supports`, otherwise warned), as is a malformed `values` list. Cloudflare can hold two objects with the same value but different metadata, which can't be represented per-value; the first is kept and a warning is logged on dump, and the same limitation applies on apply — the provider matches Cloudflare objects by value, so duplicate objects can't be individually managed and one may be left untouched.
 
 The `TagAllowListFilter`/`TagRejectListFilter` [processors](#processors) consider a record's per-value tags as well as its record-level tags — a record is treated as carrying a tag if any of its values do.
 

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -599,6 +599,9 @@ class CloudflareProvider(BaseProvider):
         proxied = records[0].get('proxied', False)
         if self.cdn and proxied:
             data = self._data_for_cdn(name, _type, records)
+            # CDN rewrites collapse to a single synthetic CNAME, so there's no
+            # per-value metadata to read back; flagged with data_for=None below.
+            data_for = None
         else:
             # Cloudflare supports ALIAS semantics with root CNAMEs
             if _type == 'CNAME' and name == '':
@@ -620,21 +623,19 @@ class CloudflareProvider(BaseProvider):
             self.log.debug('_record_for: auto-ttl=True')
             record.octodns['cloudflare'] = {'auto-ttl': True}
 
-        # update record comment
-        if records[0].get('comment'):
-            try:
-                record.octodns['cloudflare']['comment'] = records[0]['comment']
-            except KeyError:
-                record.octodns['cloudflare'] = {
-                    'comment': records[0]['comment']
-                }
-
-        # update record tags
-        if records[0].get('tags'):
-            try:
-                record.octodns['cloudflare']['tags'] = records[0]['tags']
-            except KeyError:
-                record.octodns['cloudflare'] = {'tags': records[0]['tags']}
+        # update record comment & tags. Cloudflare keeps these on each
+        # individual DNS object (one per value); when every value shares the
+        # same metadata we use the record-level octodns.cloudflare shorthand,
+        # when they differ we emit a per-value list keyed by value (see
+        # _populate_value_metadata). CDN rewrites keep the simple form.
+        if data_for is None:
+            cloudflare = record.octodns.setdefault('cloudflare', {})
+            if records[0].get('comment'):
+                cloudflare['comment'] = records[0]['comment']
+            if records[0].get('tags'):
+                cloudflare['tags'] = records[0]['tags']
+        else:
+            self._populate_value_metadata(record, _type, records, data_for)
 
         # update record region (Cloudflare Regional Services / Data
         # Localization). Region is keyed by hostname on a separate API, so it's
@@ -798,7 +799,53 @@ class CloudflareProvider(BaseProvider):
         if self.regional_services:
             self._validate_regions(desired)
 
+        self._validate_value_metadata(desired)
+
         return super()._process_desired_zone(desired)
+
+    def _validate_value_metadata(self, desired):
+        '''Per-value comment/tags (octodns.cloudflare.values) must reference
+        values that actually exist on the record. Catch mismatches at plan
+        time, where supports_warn_or_except can surface them, rather than
+        letting an entry silently no-op during apply.'''
+        for record in desired.records:
+            entries = record.octodns.get('cloudflare', {}).get('values')
+            if entries is None:
+                continue
+            if not isinstance(entries, list):
+                msg = (
+                    f'{record.fqdn} {record._type}: octodns.cloudflare.values '
+                    f'must be a list of per-value entries'
+                )
+                self.supports_warn_or_except(
+                    msg, 'ignoring octodns.cloudflare.values'
+                )
+                continue
+            actual = {
+                self._meta_value_key(getattr(value, 'data', value))
+                for value in self._values_in_content_order(record)
+            }
+            for entry in entries:
+                if not isinstance(entry, dict) or 'value' not in entry:
+                    msg = (
+                        f'{record.fqdn} {record._type}: each '
+                        f'octodns.cloudflare.values entry must be a mapping '
+                        f'with a \'value\' key; got {entry!r}'
+                    )
+                    self.supports_warn_or_except(
+                        msg, 'ignoring the malformed entry'
+                    )
+                    continue
+                if self._meta_value_key(entry['value']) not in actual:
+                    msg = (
+                        f'{record.fqdn} {record._type}: octodns.cloudflare '
+                        f'per-value metadata references value '
+                        f'{entry["value"]!r} which is not one of the '
+                        f'record\'s values'
+                    )
+                    self.supports_warn_or_except(
+                        msg, 'ignoring the unmatched per-value metadata entry'
+                    )
 
     def _validate_regions(self, desired):
         # Validate Cloudflare Regional Services (region) constraints. Region is
@@ -1012,13 +1059,158 @@ class CloudflareProvider(BaseProvider):
             and record.octodns.get('cloudflare', {}).get('auto-ttl', False)
         )
 
-    def _record_comment(self, record):
-        'Returns record comment'
+    def _values_in_content_order(self, record):
+        '''The record's value objects, parallel to _contents_for_<type>()
+        output. Single-value (ValueMixin) types expose .value; multi-value
+        (ValuesMixin) types expose .values.'''
+        values = getattr(record, 'values', None)
+        if values is None:
+            return [record.value]
+        return values
+
+    def _meta_value_key(self, value):
+        '''A hashable, comparison-stable key for a value in its native
+        (octoDNS data) form. Normalizes str subclasses (e.g. Ipv4Value) to
+        plain str and dict/list values (e.g. MX) to nested tuples so that a
+        value read from Cloudflare and the same value authored in YAML compare
+        equal.'''
+        if isinstance(value, dict):
+            return tuple(
+                sorted((k, self._meta_value_key(v)) for k, v in value.items())
+            )
+        if isinstance(value, (list, tuple)):
+            return tuple(self._meta_value_key(v) for v in value)
+        if isinstance(value, str):
+            return str(value)
+        return value
+
+    @staticmethod
+    def _norm_meta(meta):
+        '''Order-insensitive form of a (comment, tags) pair for comparison —
+        octoDNS treats tags as a set, so [a, b] and [b, a] are equal.'''
+        if meta is None:
+            return None
+        comment, tags = meta
+        return (comment, frozenset(tags))
+
+    def _value_metadata(self, record):
+        '''Per-value metadata entries (octodns.cloudflare.values) keyed by
+        value. Empty when the record uses the record-level shorthand.
+        Tolerant of malformed config (which _validate_value_metadata reports
+        at plan time) so a lenient run degrades rather than crashing.'''
+        entries = record.octodns.get('cloudflare', {}).get('values')
+        if not isinstance(entries, list):
+            return {}
+        return {
+            self._meta_value_key(entry.get('value')): entry
+            for entry in entries
+            if isinstance(entry, dict) and 'value' in entry
+        }
+
+    def _populate_value_metadata(self, record, _type, records, data_for):
+        '''Read comment/tags off each Cloudflare object and attach them to the
+        octoDNS record.
+
+        Cloudflare stores comment/tags on each individual DNS object (one per
+        value). When every value carries identical metadata we keep the
+        record-level octodns.cloudflare.comment/tags shorthand (backwards
+        compatible); when they differ we emit an explicit per-value list keyed
+        by value. Two objects sharing a value but differing in metadata can't
+        be represented per-value — we keep the first and warn.'''
+        # value-key -> (native value, meta) in first-seen order; meta is a
+        # (comment, tags-tuple) preserving Cloudflare's tag order, or None when
+        # the object has neither. _norm_meta gives an order-insensitive form
+        # for comparisons (tags are a set as far as octoDNS is concerned).
+        metadata = {}
+        order = []
+        for r in records:
+            comment = r.get('comment') or ''
+            tags = tuple(r.get('tags') or [])
+            meta = (comment, tags) if (comment or tags) else None
+            single = data_for(_type, [r])
+            native = (
+                single['values'][0]
+                if 'values' in single
+                else single.get('value')
+            )
+            key = self._meta_value_key(native)
+            if key in metadata:
+                if self._norm_meta(metadata[key][1]) != self._norm_meta(meta):
+                    self.log.warning(
+                        '%s %s: Cloudflare has multiple objects for value %r '
+                        'with differing comment/tags; octoDNS cannot represent '
+                        'per-object metadata for duplicate values — keeping '
+                        'the first',
+                        record.fqdn,
+                        _type,
+                        native,
+                    )
+                continue
+            metadata[key] = (native, meta)
+            order.append(key)
+
+        metas = [metadata[key] for key in order]
+        if all(meta is None for _native, meta in metas):
+            return
+
+        cloudflare = record.octodns.setdefault('cloudflare', {})
+        distinct = {self._norm_meta(meta) for _native, meta in metas}
+        if len(distinct) == 1:
+            # every value shares the same metadata -> record-level shorthand
+            comment, tags = metas[0][1]
+            if comment:
+                cloudflare['comment'] = comment
+            if tags:
+                cloudflare['tags'] = list(tags)
+            return
+
+        # values differ -> explicit per-value list, sorted for determinism
+        values_meta = []
+        for native, meta in sorted(
+            metas, key=lambda m: self._meta_value_key(m[0])
+        ):
+            if meta is None:
+                continue
+            comment, tags = meta
+            entry = {'value': native}
+            if comment:
+                entry['comment'] = comment
+            if tags:
+                entry['tags'] = list(tags)
+            values_meta.append(entry)
+        cloudflare['values'] = values_meta
+
+    def _record_comment(self, record, value):
+        '''Returns the comment for a value: its per-value override if set,
+        otherwise the record-level comment.'''
+        entry = self._value_metadata(record).get(
+            self._meta_value_key(getattr(value, 'data', value))
+        )
+        if entry is not None and 'comment' in entry:
+            return entry['comment']
         return record.octodns.get('cloudflare', {}).get('comment', '')
 
-    def _record_tags(self, record):
-        'Returns nonduplicate record tags'
+    def _record_tags(self, record, value):
+        '''Returns the nonduplicate tags for a value: its per-value override if
+        set, otherwise the record-level tags.'''
+        entry = self._value_metadata(record).get(
+            self._meta_value_key(getattr(value, 'data', value))
+        )
+        if entry is not None and 'tags' in entry:
+            return set(entry['tags'])
         return set(record.octodns.get('cloudflare', {}).get('tags', []))
+
+    def _metadata_signature(self, record):
+        '''Per-value (comment, tags) signature, used to detect metadata-only
+        changes that wouldn't otherwise alter the record's values.'''
+        signature = {}
+        for value in self._values_in_content_order(record):
+            key = self._meta_value_key(getattr(value, 'data', value))
+            signature[key] = (
+                self._record_comment(record, value),
+                tuple(sorted(self._record_tags(record, value))),
+            )
+        return signature
 
     def _record_region(self, record):
         'Returns the Cloudflare Regional Services region_key, or None'
@@ -1045,17 +1237,26 @@ class CloudflareProvider(BaseProvider):
                 yield content
         else:
             contents_for = getattr(self, f'_contents_for_{_type}')
-            for content in contents_for(record):
+            # _contents_for_<type>() yields one content per value in
+            # record.values order (single-value types yield one for
+            # record.value), so zipping lines each content up with its value
+            # for per-value comment/tags resolution. The contents are
+            # materialized (rather than zipped lazily) so the generator is
+            # fully drained even though zip stops on the values list.
+            values = self._values_in_content_order(record)
+            for value, content in zip(values, list(contents_for(record))):
                 content.update({'name': name, 'type': _type, 'ttl': ttl})
 
                 if _type in _PROXIABLE_RECORD_TYPES:
                     content.update({'proxied': self._record_is_proxied(record)})
 
-                if self._record_comment(record):
-                    content.update({'comment': self._record_comment(record)})
+                comment = self._record_comment(record, value)
+                if comment:
+                    content.update({'comment': comment})
 
-                if self._record_tags(record):
-                    content.update({'tags': list(self._record_tags(record))})
+                tags = self._record_tags(record, value)
+                if tags:
+                    content.update({'tags': list(tags)})
 
                 yield content
 
@@ -1548,13 +1749,16 @@ class CloudflareProvider(BaseProvider):
             ):
                 extra_changes.append(Update(existing_record, desired_record))
 
-            if self._record_comment(existing_record) != self._record_comment(
-                desired_record
-            ):
-                extra_changes.append(Update(existing_record, desired_record))
-
-            if self._record_tags(existing_record) != self._record_tags(
-                desired_record
+            # Metadata-only changes (comment/tags differing on a value that
+            # still exists on both sides). Values present on only one side are
+            # value changes, which core's diff already handles — comparing the
+            # full signature there would re-introduce changes _include_change
+            # intentionally filtered (e.g. unmanageable CDN records).
+            existing_sig = self._metadata_signature(existing_record)
+            desired_sig = self._metadata_signature(desired_record)
+            if any(
+                existing_sig[key] != desired_sig[key]
+                for key in existing_sig.keys() & desired_sig.keys()
             ):
                 extra_changes.append(Update(existing_record, desired_record))
 

--- a/octodns_cloudflare/__init__.py
+++ b/octodns_cloudflare/__init__.py
@@ -836,7 +836,7 @@ class CloudflareProvider(BaseProvider):
                         msg, 'ignoring the malformed entry'
                     )
                     continue
-                if self._meta_value_key(entry['value']) not in actual:
+                if self._entry_value_key(record, entry['value']) not in actual:
                     msg = (
                         f'{record.fqdn} {record._type}: octodns.cloudflare '
                         f'per-value metadata references value '
@@ -1093,16 +1093,35 @@ class CloudflareProvider(BaseProvider):
         comment, tags = meta
         return (comment, frozenset(tags))
 
+    def _entry_value_key(self, record, value):
+        '''Key for a per-value entry's raw (YAML-authored) value, normalized
+        through the record's value type so equivalent spellings — mixed-case
+        hostnames, uncompressed IPv6, idna forms — match the record's (already
+        normalized) values. record._value_type is technically private octoDNS
+        API, but it's been stable for years, there's no clean public
+        alternative, and this suite runs against octoDNS core PRs so drift
+        would surface early. Values the type can't parse fall back to their
+        raw form — they won't match anything and _validate_value_metadata
+        reports them at plan time.'''
+        try:
+            normalized = record._value_type(value)
+        except Exception:
+            return self._meta_value_key(value)
+        return self._meta_value_key(getattr(normalized, 'data', normalized))
+
     def _value_metadata(self, record):
         '''Per-value metadata entries (octodns.cloudflare.values) keyed by
-        value. Empty when the record uses the record-level shorthand.
-        Tolerant of malformed config (which _validate_value_metadata reports
-        at plan time) so a lenient run degrades rather than crashing.'''
+        normalized value. Empty when the record uses the record-level
+        shorthand. Tolerant of malformed config (which
+        _validate_value_metadata reports at plan time) so a lenient run
+        degrades rather than crashing. Callers that resolve metadata for more
+        than one value should call this once and pass the map to
+        _record_comment/_record_tags.'''
         entries = record.octodns.get('cloudflare', {}).get('values')
         if not isinstance(entries, list):
             return {}
         return {
-            self._meta_value_key(entry.get('value')): entry
+            self._entry_value_key(record, entry['value']): entry
             for entry in entries
             if isinstance(entry, dict) and 'value' in entry
         }
@@ -1180,20 +1199,22 @@ class CloudflareProvider(BaseProvider):
             values_meta.append(entry)
         cloudflare['values'] = values_meta
 
-    def _record_comment(self, record, value):
+    def _record_comment(self, record, value, value_metadata):
         '''Returns the comment for a value: its per-value override if set,
-        otherwise the record-level comment.'''
-        entry = self._value_metadata(record).get(
+        otherwise the record-level comment. value_metadata is the record's
+        _value_metadata map, built once by the caller.'''
+        entry = value_metadata.get(
             self._meta_value_key(getattr(value, 'data', value))
         )
         if entry is not None and 'comment' in entry:
             return entry['comment']
         return record.octodns.get('cloudflare', {}).get('comment', '')
 
-    def _record_tags(self, record, value):
+    def _record_tags(self, record, value, value_metadata):
         '''Returns the nonduplicate tags for a value: its per-value override if
-        set, otherwise the record-level tags.'''
-        entry = self._value_metadata(record).get(
+        set, otherwise the record-level tags. value_metadata is the record's
+        _value_metadata map, built once by the caller.'''
+        entry = value_metadata.get(
             self._meta_value_key(getattr(value, 'data', value))
         )
         if entry is not None and 'tags' in entry:
@@ -1203,12 +1224,13 @@ class CloudflareProvider(BaseProvider):
     def _metadata_signature(self, record):
         '''Per-value (comment, tags) signature, used to detect metadata-only
         changes that wouldn't otherwise alter the record's values.'''
+        value_metadata = self._value_metadata(record)
         signature = {}
         for value in self._values_in_content_order(record):
             key = self._meta_value_key(getattr(value, 'data', value))
             signature[key] = (
-                self._record_comment(record, value),
-                tuple(sorted(self._record_tags(record, value))),
+                self._record_comment(record, value, value_metadata),
+                tuple(sorted(self._record_tags(record, value, value_metadata))),
             )
         return signature
 
@@ -1244,17 +1266,18 @@ class CloudflareProvider(BaseProvider):
             # materialized (rather than zipped lazily) so the generator is
             # fully drained even though zip stops on the values list.
             values = self._values_in_content_order(record)
+            value_metadata = self._value_metadata(record)
             for value, content in zip(values, list(contents_for(record))):
                 content.update({'name': name, 'type': _type, 'ttl': ttl})
 
                 if _type in _PROXIABLE_RECORD_TYPES:
                     content.update({'proxied': self._record_is_proxied(record)})
 
-                comment = self._record_comment(record, value)
+                comment = self._record_comment(record, value, value_metadata)
                 if comment:
                     content.update({'comment': comment})
 
-                tags = self._record_tags(record, value)
+                tags = self._record_tags(record, value, value_metadata)
                 if tags:
                     content.update({'tags': list(tags)})
 

--- a/octodns_cloudflare/processor/filter.py
+++ b/octodns_cloudflare/processor/filter.py
@@ -27,7 +27,16 @@ class _TagBaseFilter(_FilterProcessor):
 
     def _process(self, zone, *args, **kwargs):
         for record in zone.records:
-            tags = set(record.octodns.get('cloudflare', {}).get('tags', []))
+            cloudflare = record.octodns.get('cloudflare', {})
+            # A record's tags are the union of its record-level tags and any
+            # per-value tags (octodns.cloudflare.values). Filtering is
+            # record-granular, so a record is considered to carry a tag if any
+            # of its values do. Malformed entries are tolerated here and left
+            # for the provider to report at plan time.
+            tags = set(cloudflare.get('tags') or [])
+            for entry in cloudflare.get('values') or []:
+                if isinstance(entry, dict):
+                    tags.update(entry.get('tags') or [])
             if self._tags.issubset(tags):
                 self.matches(zone, record)
             else:

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -4305,6 +4305,126 @@ class TestCloudflareProvider(TestCase):
                 ['A', 'B'], comments, f'{_type} per-value metadata lost'
             )
 
+    @patch('octodns_cloudflare.BaseProvider._process_desired_zone')
+    def test_per_value_metadata_non_canonical_values(self, mock_base):
+        # a hand-authored entry value in an equivalent-but-different spelling
+        # (mixed-case hostname, uncompressed IPv6) is normalized through the
+        # record's value type, so it still matches its record value
+        mock_base.side_effect = lambda desired: desired
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=True
+        )
+        zone = Zone('unit.tests.', [])
+
+        mx = Record.new(
+            zone,
+            'mx',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [
+                    {'preference': 10, 'exchange': 'mx1.unit.tests.'},
+                    {'preference': 20, 'exchange': 'mx2.unit.tests.'},
+                ],
+                'octodns': {
+                    'cloudflare': {
+                        'values': [
+                            {
+                                # mixed-case spelling of mx1.unit.tests.
+                                'value': {
+                                    'preference': 10,
+                                    'exchange': 'MX1.Unit.Tests.',
+                                },
+                                'comment': 'primary',
+                            }
+                        ]
+                    }
+                },
+            },
+        )
+        aaaa = Record.new(
+            zone,
+            'v6',
+            {
+                'ttl': 300,
+                'type': 'AAAA',
+                'values': ['2001:db8::1', '2001:db8::2'],
+                'octodns': {
+                    'cloudflare': {
+                        'values': [
+                            {
+                                # uncompressed, uppercase spelling
+                                'value': '2001:0DB8:0000:0000:0000:0000:0000:0001',
+                                'comment': 'uncompressed',
+                            }
+                        ]
+                    }
+                },
+            },
+        )
+
+        # matching works on the write path
+        mx_contents = {
+            d['priority']: d.get('comment') for d in provider._gen_data(mx)
+        }
+        self.assertEqual('primary', mx_contents[10])
+        self.assertIsNone(mx_contents[20])
+        aaaa_contents = {
+            d['content']: d.get('comment') for d in provider._gen_data(aaaa)
+        }
+        self.assertEqual('uncompressed', aaaa_contents['2001:db8::1'])
+        self.assertIsNone(aaaa_contents['2001:db8::2'])
+
+        # and strict plan-time validation accepts the equivalent spellings
+        desired = zone.copy()
+        desired.add_record(mx)
+        desired.add_record(aaaa)
+        result = provider._process_desired_zone(desired)
+        self.assertEqual(2, len(result.records))
+
+    @patch('octodns_cloudflare.BaseProvider._process_desired_zone')
+    def test_per_value_metadata_unparseable_value(self, mock_base):
+        # an entry value the record's value type can't parse (here an MX
+        # missing its exchange) must not crash; it falls back to its raw form,
+        # matches nothing, and is reported at plan time
+        mock_base.side_effect = lambda desired: desired
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            'mx',
+            {
+                'ttl': 300,
+                'type': 'MX',
+                'values': [{'preference': 10, 'exchange': 'mx1.unit.tests.'}],
+                'octodns': {
+                    'cloudflare': {
+                        'comment': 'record-level',
+                        'values': [
+                            {'value': {'preference': 10}, 'comment': 'nope'}
+                        ],
+                    }
+                },
+            },
+            lenient=True,
+        )
+
+        # write path degrades to the record-level comment
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=False
+        )
+        contents = list(provider._gen_data(record))
+        self.assertEqual('record-level', contents[0]['comment'])
+
+        # strict plan-time validation reports it as unmatched
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=True
+        )
+        desired = zone.copy()
+        desired.add_record(record)
+        with self.assertRaises(SupportsException) as ctx:
+            provider._process_desired_zone(desired)
+        self.assertIn('not one of the', str(ctx.exception))
+
     def test_per_value_metadata_txt(self):
         # TXT (chunked content path) round-trips per-value metadata
         provider = CloudflareProvider('test', 'email', 'token')

--- a/tests/test_octodns_provider_cloudflare.py
+++ b/tests/test_octodns_provider_cloudflare.py
@@ -3629,6 +3629,719 @@ class TestCloudflareProvider(TestCase):
             'a new comment',
         )
 
+    def test_per_value_metadata_populate_differing(self):
+        # multiple values, each Cloudflare object with its own comment/tags ->
+        # an explicit per-value list, no record-level shorthand
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'a1',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.4',
+                    'comment': 'primary',
+                    'tags': ['cdn', 'tag1'],
+                    'ttl': 300,
+                },
+                {
+                    'id': 'a2',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.5',
+                    'comment': 'failover',
+                    'tags': ['cdn', 'tag2'],
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        record = next(iter(zone.records))
+        cloudflare = record.octodns['cloudflare']
+        # differing -> per-value list and no record-level comment/tags
+        self.assertNotIn('comment', cloudflare)
+        self.assertNotIn('tags', cloudflare)
+        by_value = {e['value']: e for e in cloudflare['values']}
+        self.assertEqual(by_value['1.2.3.4']['comment'], 'primary')
+        self.assertEqual(by_value['1.2.3.4']['tags'], ['cdn', 'tag1'])
+        self.assertEqual(by_value['1.2.3.5']['comment'], 'failover')
+        self.assertEqual(by_value['1.2.3.5']['tags'], ['cdn', 'tag2'])
+
+    def test_per_value_metadata_populate_uniform(self):
+        # multiple values that all share the same metadata keep the
+        # record-level shorthand (backwards compatible, no per-value list)
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'a1',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.4',
+                    'comment': 'same',
+                    'tags': ['t'],
+                    'ttl': 300,
+                },
+                {
+                    'id': 'a2',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.5',
+                    'comment': 'same',
+                    'tags': ['t'],
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        cloudflare = next(iter(zone.records)).octodns['cloudflare']
+        self.assertEqual('same', cloudflare['comment'])
+        self.assertEqual(['t'], cloudflare['tags'])
+        self.assertNotIn('values', cloudflare)
+
+    def test_per_value_metadata_populate_partial(self):
+        # one value has metadata, the other none -> list carries only the one
+        # with metadata, no record-level default invented
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'a1',
+                    'type': 'A',
+                    'name': 'p.unit.tests',
+                    'content': '1.2.3.4',
+                    'comment': 'only',
+                    'ttl': 300,
+                },
+                {
+                    'id': 'a2',
+                    'type': 'A',
+                    'name': 'p.unit.tests',
+                    'content': '1.2.3.5',
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        record = next(iter(zone.records))
+        cloudflare = record.octodns['cloudflare']
+        self.assertNotIn('comment', cloudflare)
+        self.assertEqual(
+            ['1.2.3.4'], [e['value'] for e in cloudflare['values']]
+        )
+        self.assertEqual('only', cloudflare['values'][0]['comment'])
+        # the value without metadata gets nothing on the way back out
+        by_value = {d['content']: d for d in provider._gen_data(record)}
+        self.assertNotIn('comment', by_value['1.2.3.5'])
+        self.assertNotIn('tags', by_value['1.2.3.5'])
+        self.assertEqual('only', by_value['1.2.3.4']['comment'])
+
+    def test_per_value_metadata_gen_data_overrides(self):
+        # record-level default + sparse per-value overrides, resolved per field
+        provider = CloudflareProvider('test', 'email', 'token')
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            'multi',
+            {
+                'ttl': 300,
+                'type': 'A',
+                'values': ['1.2.3.4', '1.2.3.5', '1.2.3.6'],
+                'octodns': {
+                    'cloudflare': {
+                        'comment': 'default-c',
+                        'tags': ['default-t'],
+                        'values': [
+                            {
+                                'value': '1.2.3.4',
+                                'comment': 'c4',
+                                'tags': ['t4'],
+                            },
+                            # only tags -> comment falls back to record-level
+                            {'value': '1.2.3.5', 'tags': ['t5']},
+                        ],
+                    }
+                },
+            },
+        )
+        by_value = {d['content']: d for d in provider._gen_data(record)}
+        # fully overridden
+        self.assertEqual('c4', by_value['1.2.3.4']['comment'])
+        self.assertEqual(['t4'], by_value['1.2.3.4']['tags'])
+        # tags overridden, comment inherits record-level default
+        self.assertEqual('default-c', by_value['1.2.3.5']['comment'])
+        self.assertEqual(['t5'], by_value['1.2.3.5']['tags'])
+        # no entry -> record-level default for both
+        self.assertEqual('default-c', by_value['1.2.3.6']['comment'])
+        self.assertEqual(['default-t'], by_value['1.2.3.6']['tags'])
+
+    def test_record_level_metadata_applies_to_all_values(self):
+        # backwards compat: record-level comment/tags with no per-value list
+        # apply to every value
+        provider = CloudflareProvider('test', 'email', 'token')
+        zone = Zone('unit.tests.', [])
+        record = Record.new(
+            zone,
+            'multi',
+            {
+                'ttl': 300,
+                'type': 'A',
+                'values': ['1.2.3.4', '1.2.3.5'],
+                'octodns': {'cloudflare': {'comment': 'shared', 'tags': ['t']}},
+            },
+        )
+        for content in provider._gen_data(record):
+            self.assertEqual('shared', content['comment'])
+            self.assertEqual(['t'], content['tags'])
+
+    def test_per_value_metadata_round_trip(self):
+        # dump then re-emit reproduces each value's comment/tags
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'a1',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.4',
+                    'comment': 'primary',
+                    'tags': ['tag1'],
+                    'ttl': 300,
+                },
+                {
+                    'id': 'a2',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.5',
+                    'comment': 'failover',
+                    'tags': ['tag2'],
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        record = next(iter(zone.records))
+        by_value = {d['content']: d for d in provider._gen_data(record)}
+        self.assertEqual('primary', by_value['1.2.3.4']['comment'])
+        self.assertEqual(['tag1'], by_value['1.2.3.4']['tags'])
+        self.assertEqual('failover', by_value['1.2.3.5']['comment'])
+        self.assertEqual(['tag2'], by_value['1.2.3.5']['tags'])
+
+    def test_per_value_metadata_extra_changes(self):
+        # a metadata-only change on one value yields exactly one Update;
+        # identical metadata yields none
+        provider = CloudflareProvider('test', 'email', 'token')
+
+        def records(comment_4):
+            return [
+                {
+                    'id': 'a1',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.4',
+                    'comment': comment_4,
+                    'ttl': 300,
+                },
+                {
+                    'id': 'a2',
+                    'type': 'A',
+                    'name': 'multi.unit.tests',
+                    'content': '1.2.3.5',
+                    'comment': 'failover',
+                    'ttl': 300,
+                },
+            ]
+
+        provider.zone_records = Mock(return_value=records('primary'))
+        existing = Zone('unit.tests.', [])
+        provider.populate(existing)
+
+        provider.zone_records = Mock(return_value=records('primary-changed'))
+        desired = Zone('unit.tests.', [])
+        provider.populate(desired)
+        changes = existing.changes(desired, provider)
+        extra = provider._extra_changes(existing, desired, changes)
+        self.assertEqual(1, len(extra))
+
+        # no metadata change -> no extra change
+        provider.zone_records = Mock(return_value=records('primary'))
+        same = Zone('unit.tests.', [])
+        provider.populate(same)
+        self.assertEqual(
+            0,
+            len(
+                provider._extra_changes(
+                    existing, same, existing.changes(same, provider)
+                )
+            ),
+        )
+
+    @patch('octodns_cloudflare.BaseProvider._process_desired_zone')
+    def test_per_value_metadata_validation(self, mock_base):
+        mock_base.side_effect = lambda desired: desired
+        zone = Zone('unit.tests.', [])
+
+        def make_desired():
+            desired = zone.copy()
+            desired.add_record(
+                Record.new(
+                    zone,
+                    'multi',
+                    {
+                        'ttl': 300,
+                        'type': 'A',
+                        'values': ['1.2.3.4', '1.2.3.5'],
+                        'octodns': {
+                            'cloudflare': {
+                                'values': [
+                                    {'value': '9.9.9.9', 'comment': 'orphan'}
+                                ]
+                            }
+                        },
+                    },
+                )
+            )
+            return desired
+
+        # strict -> a value not on the record is a plan-time error
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=True
+        )
+        with self.assertRaises(SupportsException) as ctx:
+            provider._process_desired_zone(make_desired())
+        self.assertIn('not one of the', str(ctx.exception))
+        self.assertIn('9.9.9.9', str(ctx.exception))
+
+        # non-strict -> warn and pass through
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=False
+        )
+        result = provider._process_desired_zone(make_desired())
+        self.assertEqual(1, len(result.records))
+
+        # an entry that references a real value passes validation cleanly,
+        # even in strict mode
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=True
+        )
+        valid = zone.copy()
+        valid.add_record(
+            Record.new(
+                zone,
+                'multi',
+                {
+                    'ttl': 300,
+                    'type': 'A',
+                    'values': ['1.2.3.4', '1.2.3.5'],
+                    'octodns': {
+                        'cloudflare': {
+                            'values': [{'value': '1.2.3.4', 'comment': 'ok'}]
+                        }
+                    },
+                },
+            )
+        )
+        result = provider._process_desired_zone(valid)
+        self.assertEqual(1, len(result.records))
+
+    @patch('octodns_cloudflare.BaseProvider._process_desired_zone')
+    def test_per_value_metadata_malformed(self, mock_base):
+        mock_base.side_effect = lambda desired: desired
+        zone = Zone('unit.tests.', [])
+
+        def desired_with(values):
+            desired = zone.copy()
+            desired.add_record(
+                Record.new(
+                    zone,
+                    'm',
+                    {
+                        'ttl': 300,
+                        'type': 'A',
+                        'values': ['1.2.3.4', '1.2.3.5'],
+                        'octodns': {'cloudflare': {'values': values}},
+                    },
+                    lenient=True,
+                )
+            )
+            return desired
+
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=True
+        )
+        # values is not a list
+        with self.assertRaises(SupportsException) as ctx:
+            provider._process_desired_zone(
+                desired_with({'1.2.3.4': {'comment': 'x'}})
+            )
+        self.assertIn('must be a list', str(ctx.exception))
+        # an entry that is not a mapping
+        with self.assertRaises(SupportsException) as ctx:
+            provider._process_desired_zone(desired_with(['oops']))
+        self.assertIn('must be a mapping', str(ctx.exception))
+        # a mapping entry missing its 'value' key
+        with self.assertRaises(SupportsException) as ctx:
+            provider._process_desired_zone(
+                desired_with([{'comment': 'no value'}])
+            )
+        self.assertIn('must be a mapping', str(ctx.exception))
+
+        # non-strict: malformed config warns and degrades rather than crashing
+        provider = CloudflareProvider(
+            'test', 'email', 'token', strict_supports=False
+        )
+        result = provider._process_desired_zone(
+            desired_with(['oops', {'value': '1.2.3.4', 'comment': 'ok'}])
+        )
+        self.assertEqual(1, len(result.records))
+        # the bad entry is skipped; the good one still applies
+        rec = next(iter(result.records))
+        by_value = {d['content']: d for d in provider._gen_data(rec)}
+        self.assertEqual('ok', by_value['1.2.3.4']['comment'])
+        self.assertNotIn('comment', by_value['1.2.3.5'])
+
+        # non-strict + a non-list values warns and passes the record through
+        result = provider._process_desired_zone(
+            desired_with({'1.2.3.4': {'comment': 'x'}})
+        )
+        self.assertEqual(1, len(result.records))
+
+        # a non-list values is ignored entirely by _gen_data, which falls back
+        # to the record-level comment
+        rec2 = Record.new(
+            zone,
+            'm2',
+            {
+                'ttl': 300,
+                'type': 'A',
+                'value': '9.9.9.9',
+                'octodns': {
+                    'cloudflare': {
+                        'comment': 'record-level',
+                        'values': {'9.9.9.9': {'comment': 'ignored'}},
+                    }
+                },
+            },
+            lenient=True,
+        )
+        self.assertEqual(
+            'record-level', next(provider._gen_data(rec2))['comment']
+        )
+
+    def test_per_value_metadata_duplicate_value_warns(self):
+        # two Cloudflare objects sharing a value but differing in metadata
+        # can't be represented per-value -> keep the first and warn
+        provider = CloudflareProvider('test', 'email', 'token')
+        zone = Zone('unit.tests.', [])
+        records = [
+            {
+                'id': 'a1',
+                'type': 'A',
+                'name': 'dup.unit.tests',
+                'content': '1.2.3.4',
+                'comment': 'first',
+                'ttl': 300,
+            },
+            {
+                'id': 'a2',
+                'type': 'A',
+                'name': 'dup.unit.tests',
+                'content': '1.2.3.4',
+                'comment': 'second',
+                'ttl': 300,
+            },
+        ]
+        with self.assertLogs(provider.log, level='WARNING') as cm:
+            record = provider._record_for(zone, 'dup', 'A', records, True)
+        self.assertTrue(any('duplicate values' in line for line in cm.output))
+        self.assertEqual('first', record.octodns['cloudflare']['comment'])
+
+    def test_per_value_metadata_duplicate_value_identical(self):
+        # duplicate value carrying identical metadata is deduped silently and
+        # collapses to the record-level shorthand (no warning, no list)
+        provider = CloudflareProvider('test', 'email', 'token')
+        zone = Zone('unit.tests.', [])
+        records = [
+            {
+                'id': 'a1',
+                'type': 'A',
+                'name': 'dup.unit.tests',
+                'content': '1.2.3.4',
+                'comment': 'same',
+                'tags': ['t'],
+                'ttl': 300,
+            },
+            {
+                'id': 'a2',
+                'type': 'A',
+                'name': 'dup.unit.tests',
+                'content': '1.2.3.4',
+                'comment': 'same',
+                'tags': ['t'],
+                'ttl': 300,
+            },
+        ]
+        record = provider._record_for(zone, 'dup', 'A', records, True)
+        cloudflare = record.octodns['cloudflare']
+        self.assertEqual('same', cloudflare['comment'])
+        self.assertEqual(['t'], cloudflare['tags'])
+        self.assertNotIn('values', cloudflare)
+
+    def test_per_value_metadata_tags_only_entry(self):
+        # differing values where one carries only tags and the other only a
+        # comment -> each emitted entry omits the field it lacks
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'a1',
+                    'type': 'A',
+                    'name': 'm.unit.tests',
+                    'content': '1.2.3.4',
+                    'tags': ['t4'],
+                    'ttl': 300,
+                },
+                {
+                    'id': 'a2',
+                    'type': 'A',
+                    'name': 'm.unit.tests',
+                    'content': '1.2.3.5',
+                    'comment': 'c5',
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        by_value = {
+            e['value']: e
+            for e in next(iter(zone.records)).octodns['cloudflare']['values']
+        }
+        self.assertEqual(['t4'], by_value['1.2.3.4']['tags'])
+        self.assertNotIn('comment', by_value['1.2.3.4'])
+        self.assertEqual('c5', by_value['1.2.3.5']['comment'])
+        self.assertNotIn('tags', by_value['1.2.3.5'])
+
+    def test_cdn_comment_tags(self):
+        # CDN rewrites collapse to a single synthetic CNAME and keep the
+        # record-level comment/tags shorthand (no per-value list)
+        provider = CloudflareProvider(
+            'test', 'email', 'token', 'account_id', True
+        )
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'c1',
+                    'type': 'A',
+                    'name': 'a.unit.tests',
+                    'content': '1.1.1.1',
+                    'proxiable': True,
+                    'proxied': True,
+                    'comment': 'cdn comment',
+                    'tags': ['cdn-tag'],
+                    'ttl': 300,
+                }
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        cloudflare = next(iter(zone.records)).octodns['cloudflare']
+        self.assertEqual('cdn comment', cloudflare['comment'])
+        self.assertEqual(['cdn-tag'], cloudflare['tags'])
+        self.assertNotIn('values', cloudflare)
+
+    def test_per_value_metadata_mx(self):
+        # structured-value type round-trips per-value metadata
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 'm1',
+                    'type': 'MX',
+                    'name': 'unit.tests',
+                    'content': 'mx1.unit.tests',
+                    'priority': 10,
+                    'comment': 'primary',
+                    'ttl': 300,
+                },
+                {
+                    'id': 'm2',
+                    'type': 'MX',
+                    'name': 'unit.tests',
+                    'content': 'mx2.unit.tests',
+                    'priority': 20,
+                    'comment': 'backup',
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        record = next(iter(zone.records))
+        by_value = {
+            (e['value']['preference'], e['value']['exchange']): e
+            for e in record.octodns['cloudflare']['values']
+        }
+        self.assertEqual(
+            'primary', by_value[(10, 'mx1.unit.tests.')]['comment']
+        )
+        self.assertEqual('backup', by_value[(20, 'mx2.unit.tests.')]['comment'])
+        # and it survives the trip back out to Cloudflare contents
+        contents = {
+            (d['priority'], d['content']): d for d in provider._gen_data(record)
+        }
+        self.assertEqual(
+            'primary', contents[(10, 'mx1.unit.tests.')]['comment']
+        )
+        self.assertEqual('backup', contents[(20, 'mx2.unit.tests.')]['comment'])
+
+    def test_per_value_metadata_structured_round_trip(self):
+        # every structured-value type ross called out (CAA/SRV/LOC/NAPTR) must
+        # round-trip per-value metadata: the value-key stored on read has to
+        # match the value-key looked up on write even though the value is a
+        # multi-field dict rather than a scalar
+        provider = CloudflareProvider('test', 'email', 'token')
+        cases = {
+            'CAA': (
+                'ca',
+                [
+                    {
+                        'type': 'CAA',
+                        'name': 'ca.unit.tests',
+                        'data': {'flags': 0, 'tag': 'issue', 'value': 'le.org'},
+                        'ttl': 300,
+                        'comment': 'A',
+                    },
+                    {
+                        'type': 'CAA',
+                        'name': 'ca.unit.tests',
+                        'data': {
+                            'flags': 0,
+                            'tag': 'issuewild',
+                            'value': 'ca2.org',
+                        },
+                        'ttl': 300,
+                        'comment': 'B',
+                    },
+                ],
+            ),
+            'SRV': (
+                '_sip._tcp',
+                [
+                    {
+                        'type': 'SRV',
+                        'name': '_sip._tcp.unit.tests',
+                        'data': {
+                            'priority': 10,
+                            'weight': 20,
+                            'port': 5060,
+                            'target': 'sip1.unit.tests',
+                        },
+                        'ttl': 300,
+                        'comment': 'A',
+                    },
+                    {
+                        'type': 'SRV',
+                        'name': '_sip._tcp.unit.tests',
+                        'data': {
+                            'priority': 20,
+                            'weight': 20,
+                            'port': 5061,
+                            'target': 'sip2.unit.tests',
+                        },
+                        'ttl': 300,
+                        'comment': 'B',
+                    },
+                ],
+            ),
+            'NAPTR': (
+                'naptr',
+                [
+                    {
+                        'type': 'NAPTR',
+                        'name': 'naptr.unit.tests',
+                        'data': {
+                            'flags': 'U',
+                            'order': 100,
+                            'preference': 10,
+                            'regex': '!^.*$!sip:a@b.example.com!',
+                            'replacement': '.',
+                            'service': 'SIP+D2U',
+                        },
+                        'ttl': 300,
+                        'comment': 'A',
+                    },
+                    {
+                        'type': 'NAPTR',
+                        'name': 'naptr.unit.tests',
+                        'data': {
+                            'flags': 'U',
+                            'order': 100,
+                            'preference': 20,
+                            'regex': '!^.*$!sip:c@d.example.com!',
+                            'replacement': '.',
+                            'service': 'SIP+D2T',
+                        },
+                        'ttl': 300,
+                        'comment': 'B',
+                    },
+                ],
+            ),
+        }
+        for _type, (name, records) in cases.items():
+            zone = Zone('unit.tests.', [])
+            record = provider._record_for(zone, name, _type, records, True)
+            # differing per-value metadata -> an explicit per-value list
+            self.assertIn('values', record.octodns['cloudflare'])
+            # every value's comment survives the trip back out to Cloudflare
+            comments = sorted(
+                d.get('comment') for d in provider._gen_data(record)
+            )
+            self.assertEqual(
+                ['A', 'B'], comments, f'{_type} per-value metadata lost'
+            )
+
+    def test_per_value_metadata_txt(self):
+        # TXT (chunked content path) round-trips per-value metadata
+        provider = CloudflareProvider('test', 'email', 'token')
+        provider.zone_records = Mock(
+            return_value=[
+                {
+                    'id': 't1',
+                    'type': 'TXT',
+                    'name': 'txt.unit.tests',
+                    'content': 'verification=abc',
+                    'comment': 'search',
+                    'ttl': 300,
+                },
+                {
+                    'id': 't2',
+                    'type': 'TXT',
+                    'name': 'txt.unit.tests',
+                    'content': 'v=spf1 ~all',
+                    'comment': 'spf',
+                    'ttl': 300,
+                },
+            ]
+        )
+        zone = Zone('unit.tests.', [])
+        provider.populate(zone)
+        record = next(iter(zone.records))
+        by_value = {
+            e['value']: e for e in record.octodns['cloudflare']['values']
+        }
+        self.assertEqual('search', by_value['verification=abc']['comment'])
+        self.assertEqual('spf', by_value['v=spf1 ~all']['comment'])
+        # Cloudflare TXT content is quoted; the per-value comment still lines
+        # up with the right (chunked) content
+        contents = {d['content']: d for d in provider._gen_data(record)}
+        self.assertEqual('search', contents['"verification=abc"']['comment'])
+        self.assertEqual('spf', contents['"v=spf1 ~all"']['comment'])
+
     def test_change_keyer(self):
         provider = CloudflareProvider('test', 'email', 'token')
 

--- a/tests/test_octodns_provider_cloudflare_processor_filter.py
+++ b/tests/test_octodns_provider_cloudflare_processor_filter.py
@@ -128,3 +128,82 @@ class TestTagRejectListFilter(TestCase):
         want = {'foo', 'bar', 'baz', 'qux'}
         got = processor.process_target_zone(zone.copy())
         self.assertEqual(want, {r.name for r in got.records})
+
+
+class TestTagFilterPerValue(TestCase):
+    # a record's tags are the union of record-level and per-value tags
+    def _zone(self):
+        z = Zone('unit.tests.', [])
+        # per-value tags only, no record-level tags
+        z.add_record(
+            Record.new(
+                z,
+                'pv',
+                {
+                    'ttl': 300,
+                    'type': 'A',
+                    'values': ['1.2.3.4', '1.2.3.5'],
+                    'octodns': {
+                        'cloudflare': {
+                            'values': [
+                                {
+                                    'value': '1.2.3.4',
+                                    'tags': ['team:engineering'],
+                                },
+                                {'value': '1.2.3.5', 'tags': ['other']},
+                            ]
+                        }
+                    },
+                },
+            )
+        )
+        # record-level tag unioned with a per-value tag
+        z.add_record(
+            Record.new(
+                z,
+                'mix',
+                {
+                    'ttl': 300,
+                    'type': 'A',
+                    'value': '1.2.3.6',
+                    'octodns': {
+                        'cloudflare': {
+                            'tags': ['managed-by:terraform'],
+                            'values': [
+                                {
+                                    'value': '1.2.3.6',
+                                    'tags': ['team:engineering'],
+                                }
+                            ],
+                        }
+                    },
+                },
+            )
+        )
+        # malformed per-value entries are tolerated (no crash); the record
+        # ends up with no usable tags
+        z.add_record(
+            Record.new(
+                z,
+                'bad',
+                {
+                    'ttl': 300,
+                    'type': 'A',
+                    'value': '1.2.3.7',
+                    'octodns': {
+                        'cloudflare': {'values': ['oops', {'value': '1.2.3.7'}]}
+                    },
+                },
+            )
+        )
+        return z
+
+    def test_allow_matches_per_value_tags(self):
+        processor = TagAllowListFilter('allow', ['team:engineering'])
+        got = processor.process_source_zone(self._zone().copy())
+        self.assertEqual({'pv', 'mix'}, {r.name for r in got.records})
+
+    def test_reject_matches_per_value_tags(self):
+        processor = TagRejectListFilter('reject', ['team:engineering'])
+        got = processor.process_source_zone(self._zone().copy())
+        self.assertEqual({'bad'}, {r.name for r in got.records})


### PR DESCRIPTION
Closes #142.

## Summary

Cloudflare stores `comment` and `tags` on each individual DNS object — one per name+type+**value**. octoDNS collapses all values of a name+type into a single record with one record-level `octodns.cloudflare`, so a multi-value record could only carry one object's metadata; the rest was dropped on dump and overwritten on apply.

This adds an optional **`octodns.cloudflare.values`** list — one entry per value, each restating its value in the same shape it has in the record's `values:` and matched by value identity (not position) — that overrides the record-level `comment`/`tags` per value. It's purely additive: existing configs are untouched, and records whose values all share the same metadata keep the current record-level shorthand.

This is the list-of-entries form we landed on in the issue discussion.

## Behaviour

A multi-value record whose values carry different metadata now round-trips losslessly:

```yaml
bob:
  octodns:
    cloudflare:
      values:
      - value: 151.101.193.10
        comment: primary
        tags: [cdn, tag1]
      - value: 151.101.65.10
        comment: failover
        tags: [cdn, tag2]
  ttl: 300
  type: A
  values: [151.101.193.10, 151.101.65.10]
```

Record-level `comment`/`tags` remain a default for any value without its own entry, so you can mix a default with sparse overrides:

```yaml
www:
  octodns:
    cloudflare:
      comment: managed-by-octodns      # default for both values
      tags: [team:web]
      values:
      - value: 203.0.113.9             # override just this one
        comment: legacy-box
        tags: [team:web, deprecated]
  ttl: 300
  type: A
  values: [203.0.113.8, 203.0.113.9]
```

Resolution is per field: a value uses its entry's `comment`/`tags` where present, otherwise the record-level value (record-level tags apply only when a value has no tags of its own — a clean override, not a merge).

**Structured-value types are first-class** — the entry restates the value in its native shape, so MX/SRV/CAA/LOC/NAPTR work the same way as scalar types:

```yaml
aspmx:
  octodns:
    cloudflare:
      values:
      - value: {preference: 10, exchange: mx1.example.com.}
        comment: primary MX
      - value: {preference: 20, exchange: mx2.example.com.}
        comment: backup MX
  ttl: 300
  type: MX
  values:
  - {preference: 10, exchange: mx1.example.com.}
  - {preference: 20, exchange: mx2.example.com.}
```

**Dump** emits the record-level shorthand when every value shares the same metadata, and the explicit per-value list (no record-level default) when they differ.

**Validation** happens at plan time, in `_process_desired_zone`: a `values` entry that references a value not on the record (or a malformed `values`) is reported via `strict_supports` (raised in strict mode, warned otherwise) rather than silently no-op'ing at apply.

**Duplicate values** are the one case the per-value list can't represent — two Cloudflare objects sharing a value but differing in metadata. There the first is kept and a warning is logged on dump.

## Scope of the change

The core change is contained to the three seams we discussed — read (`_record_for`), write (`_gen_data`), and change detection (`_extra_changes`) — plus the plan-time validation hook.

One change reaches a bit further, and I want to flag it explicitly: `TagAllowListFilter`/`TagRejectListFilter` (`processor/filter.py`) previously matched on record-level tags only, so a record tagged solely at the per-value level would have been invisible to tag filtering — the headline use case for tags. They now match on the union of record-level and per-value tags. This only changes behaviour for records that use the new per-value tags. Happy to split it into a follow-up PR if you'd rather keep this one strictly to the provider seams.

## Tests

Full unit coverage for read (shorthand/list/partial/duplicate), write (override/fallback/record-level), change detection, plan-time validation (unmatched and malformed entries), structured-type round-trips (CAA/SRV/LOC/NAPTR/MX), TXT chunking/escaping, and the tag-filter union. 100% line+branch coverage maintained.
