### PR TITLE
Ignore octoDNS 2.0 deprecation warnings

### DIFF
--- a/.changelog/b131f92455f143c6bad8317546d65df7.md
+++ b/.changelog/b131f92455f143c6bad8317546d65df7.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Ignore octoDNS 2.0 deprecation warnings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,5 +84,6 @@ sections="FUTURE,STDLIB,THIRDPARTY,OCTODNS,FIRSTPARTY,LOCALFOLDER"
 [tool.pytest.ini_options]
 filterwarnings = [
     'error',
+    'ignore:.*DEPRECATED.*2.0',
 ]
 pythonpath = "."


### PR DESCRIPTION
Ignore deprecation warnings for APIs scheduled for removal in octoDNS 2.0 while retaining warning-as-error behavior for all other warnings.

These warnings will be addressed when this module migrates to the octoDNS 2.x APIs.

/cc octodns/octodns#1452 Validate downstream compatibility for the RDATA API migration